### PR TITLE
Make the creation of webhook optional when creating codeset

### DIFF
--- a/pkg/core/codeset_store.go
+++ b/pkg/core/codeset_store.go
@@ -6,6 +6,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/fuseml/fuseml-core/gen/codeset"
+
+	config "github.com/fuseml/fuseml-core/pkg/core/config"
 )
 
 // CodesetStore is an inteface to codeset stores
@@ -17,7 +19,7 @@ type CodesetStore interface {
 
 // GitAdmin is an inteface to git administration clients
 type GitAdmin interface {
-	PrepareRepository(code *codeset.Codeset) error
+	PrepareRepository(*codeset.Codeset, *string) error
 	GetRepositories(org, label *string) ([]*codeset.Codeset, error)
 	GetRepository(org, name string) (*codeset.Codeset, error)
 }
@@ -54,7 +56,9 @@ func (cs *GitCodesetStore) GetAll(ctx context.Context, project, label *string) (
 
 // Add creates new codeset
 func (cs *GitCodesetStore) Add(ctx context.Context, c *codeset.Codeset) (*codeset.Codeset, error) {
-	err := cs.gitAdmin.PrepareRepository(c)
+	var listenerURL *string
+	listenerURL = &config.StagingEventListenerURL
+	err := cs.gitAdmin.PrepareRepository(c, listenerURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "Preparing Repository failed")
 	}

--- a/pkg/core/gitea/client_test.go
+++ b/pkg/core/gitea/client_test.go
@@ -118,10 +118,12 @@ func (tc testGiteaClient) ListMyOrgs(gitea.ListOrgsOptions) ([]*gitea.Organizati
 }
 
 var (
-	project1 = "test-project1"
-	project2 = "test-project2"
-	name     = "test"
-	testURL  = "http://gitea.example.io"
+	project1              = "test-project1"
+	project2              = "test-project2"
+	name                  = "test"
+	testURL               = "http://gitea.example.io"
+	testListenerStringURL = "tekton-listener"
+	testListenerURL       = &testListenerStringURL
 )
 
 func getTestCodeset() *codeset.Codeset {
@@ -157,7 +159,7 @@ func TestPrepareRepository(t *testing.T) {
 		t.Errorf("Initial number of teams is not empty")
 	}
 
-	err := testGiteaAdminClient.PrepareRepository(code)
+	err := testGiteaAdminClient.PrepareRepository(code, testListenerURL)
 	if err != nil {
 		t.Errorf("Error preparing repository: %v", err)
 	}
@@ -191,7 +193,7 @@ func TestGetRepository(t *testing.T) {
 	assertError(t, err, errRepoNotFound)
 
 	// Prepare new repo
-	testGiteaAdminClient.PrepareRepository(getTestCodeset())
+	testGiteaAdminClient.PrepareRepository(getTestCodeset(), testListenerURL)
 
 	// Get the repo now
 	c, err := testGiteaAdminClient.GetRepository(project1, name)
@@ -214,7 +216,7 @@ func TestGetRepositories(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error reading list of repositories")
 	}
-	testGiteaAdminClient.PrepareRepository(getTestCodeset())
+	testGiteaAdminClient.PrepareRepository(getTestCodeset(), testListenerURL)
 
 	repos, _ = testGiteaAdminClient.GetRepositories(&project1, nil)
 	if len(repos) < 1 {
@@ -224,7 +226,7 @@ func TestGetRepositories(t *testing.T) {
 	// now add new project+repo and list all repos accross projects
 	codeset2 := getTestCodeset()
 	codeset2.Project = project2
-	testGiteaAdminClient.PrepareRepository(codeset2)
+	testGiteaAdminClient.PrepareRepository(codeset2, testListenerURL)
 
 	repos, _ = testGiteaAdminClient.GetRepositories(nil, nil)
 	if len(repos) != 2 {


### PR DESCRIPTION
PrepareRepository has additional argument pointing to listener
URL. If it is nil, webhook will not be created.

This is just initial idea. I think in the end, CreateRepoWebhook or EditRepoWebhook needs to be part of the API, so that whoever wants to modify it, do not need to access gitea client directly.