### PR TITLE
Do not create default webhook when Codeset is created

### DIFF
--- a/pkg/core/codeset_store.go
+++ b/pkg/core/codeset_store.go
@@ -6,8 +6,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/fuseml/fuseml-core/gen/codeset"
-
-	config "github.com/fuseml/fuseml-core/pkg/core/config"
 )
 
 // GitAdmin is an inteface to git administration clients
@@ -59,9 +57,7 @@ func (cs *GitCodesetStore) CreateWebhook(ctx context.Context, c *codeset.Codeset
 
 // Add creates new codeset
 func (cs *GitCodesetStore) Add(ctx context.Context, c *codeset.Codeset) (*codeset.Codeset, error) {
-	var listenerURL *string
-	listenerURL = &config.StagingEventListenerURL
-	err := cs.gitAdmin.PrepareRepository(c, listenerURL)
+	err := cs.gitAdmin.PrepareRepository(c, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "Preparing Repository failed")
 	}

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -10,9 +10,6 @@ var (
 
 	// HookSecret is the default secret used when creating repository hooks
 	HookSecret = "generatedsecret"
-
-	// StagingEventListenerURL is the default name of event listener
-	StagingEventListenerURL = "http://el-mlflow-listener.fuseml-workloads:8080"
 )
 
 // DefaultUserName returns default user name for new per-project user


### PR DESCRIPTION
Remove the variable StagingEventListenerURL with fixed value,
Codesets should rather have webhook defined once they are assigned
to a workflow.