### PR TITLE
Add unit tests for tekton workflow backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.16
 require (
 	code.gitea.io/sdk/gitea v0.14.0
 	github.com/dimfeld/httptreemux/v5 v5.3.0 // indirect
+	github.com/ghodss/yaml v1.0.0
+	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -563,6 +563,7 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=

--- a/pkg/core/tekton/tekton_test.go
+++ b/pkg/core/tekton/tekton_test.go
@@ -1,0 +1,296 @@
+package tekton
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
+	"github.com/tektoncd/pipeline/test/diff"
+	"github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
+	faketriggersclient "github.com/tektoncd/triggers/pkg/client/injection/client/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	rtesting "knative.dev/pkg/reconciler/testing"
+
+	"github.com/fuseml/fuseml-core/gen/codeset"
+	"github.com/fuseml/fuseml-core/gen/workflow"
+)
+
+const (
+	fuseMLWorkflow            = "testdata/workflow.yaml"
+	wantTektonPipeline        = "testdata/tekton-pipeline.yaml"
+	wantTektonPipelineRun     = "testdata/tekton-pipeline-run.yaml"
+	wantTektonTriggerTemplate = "testdata/tekton-trigger-template.yaml"
+	wantTektonTriggerBinding  = "testdata/tekton-trigger-binding.yaml"
+	wantTektonEventListener   = "testdata/tekton-event-listener.yaml"
+	testNamespace             = "test-namespace"
+)
+
+func TestCreateWorkflow(t *testing.T) {
+	t.Run("new workflow", func(t *testing.T) {
+		ctx, b, logs, logsOutput := initBackend(t)
+
+		w := workflow.Workflow{}
+		readYaml(t, fuseMLWorkflow, &w)
+
+		err := b.CreateWorkflow(ctx, logs, &w)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertStrings(t, strings.TrimSuffix(logsOutput.String(), "\n"), "Creating tekton pipeline for workflow: mlflow-sklearn-e2e...")
+
+		got, err := b.tektonClients.PipelineClient.Get(ctx, w.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get Pipeline %q: %s", w.Name, err)
+		}
+
+		want := v1beta1.Pipeline{}
+		readYaml(t, wantTektonPipeline, &want)
+
+		ignoreTypeMetaField := cmpopts.IgnoreFields(v1beta1.Pipeline{}, "TypeMeta")
+		if d := cmp.Diff(want, *got, cmpopts.SortSlices(func(x, y v1beta1.Param) bool { return x.Name < y.Name }), ignoreTypeMetaField); d != "" {
+			t.Errorf("Unexpected Pipeline: %s", diff.PrintWantGot(d))
+		}
+	})
+
+	t.Run("existing workflow", func(t *testing.T) {
+		ctx, b, logs, _ := initBackend(t)
+
+		w := workflow.Workflow{}
+		readYaml(t, fuseMLWorkflow, &w)
+
+		err := b.CreateWorkflow(ctx, logs, &w)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := b.CreateWorkflow(ctx, logs, &w)
+		assertError(t, got, ErrWorkflowExists)
+	})
+}
+
+func TestCreateWorkflowRun(t *testing.T) {
+	ctx, b, logs, _ := initBackend(t)
+
+	w := workflow.Workflow{}
+	readYaml(t, fuseMLWorkflow, &w)
+
+	err := b.CreateWorkflow(ctx, logs, &w)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csURL := "http://gitea.10.160.5.140.nip.io/workspace/mlflow-app-01.git"
+	cs := codeset.Codeset{Name: "mlflow-app-01", Project: "workspace", URL: &csURL}
+	err = b.CreateWorkflowRun(ctx, w.Name, cs)
+	if err != nil {
+		t.Fatalf("Failed to create workflow run %q: %s", w.Name, err)
+	}
+
+	runs, err := b.tektonClients.PipelineRunClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to list PipelineRuns: %s", err)
+	}
+
+	if len(runs.Items) > 1 {
+		t.Errorf("Expected 1 PipelineRun, got %q", len(runs.Items))
+	}
+
+	got := runs.Items[0]
+	want := v1beta1.PipelineRun{}
+	readYaml(t, wantTektonPipelineRun, &want)
+
+	ignoreStatusField := cmpopts.IgnoreFields(v1beta1.PipelineRunStatus{}, "Conditions", "PipelineRunStatusFields")
+	if d := cmp.Diff(want, got, ignoreStatusField); d != "" {
+		t.Errorf("Unexpected PipelineRun: %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestCreateListener(t *testing.T) {
+	t.Run("new listener", func(t *testing.T) {
+
+		ctx, b, logs, logsOutput := initBackend(t)
+
+		discardOutput := bytes.Buffer{}
+		discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
+		w := workflow.Workflow{}
+		readYaml(t, fuseMLWorkflow, &w)
+
+		err := b.CreateWorkflow(ctx, discardLogs, &w)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		url, err := b.CreateListener(ctx, logs, w.Name, false)
+		if err != nil {
+			t.Fatalf("Failed to create listener for workflow %q: %s", w.Name, err)
+		}
+
+		assertStrings(t, url, fmt.Sprintf("http://el-%s.%s.svc.cluster.local:8080", w.Name, b.namespace))
+
+		expectedLog := `Creating tekton trigger template for workflow: mlflow-sklearn-e2e...
+Creating tekton trigger binding for workflow: mlflow-sklearn-e2e...
+Creating tekton event listener for workflow: mlflow-sklearn-e2e...
+`
+
+		assertStrings(t, logsOutput.String(), expectedLog)
+
+		gotTriggerTemplate, err := b.tektonClients.TriggerTemplateClient.Get(ctx, w.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantTriggerTemplate := v1alpha1.TriggerTemplate{}
+		readYaml(t, wantTektonTriggerTemplate, &wantTriggerTemplate)
+
+		// The resource template from a TriggerTemplate is stored as runtime.RawExtension (bytes)
+		// so, ignore it here and compare it after unmarshalling it to a PipelineRun.
+		ignoreTypeMetaField := cmpopts.IgnoreFields(v1alpha1.TriggerTemplate{}, "TypeMeta")
+		ignoreRawTemplateField := cmpopts.IgnoreFields(runtime.RawExtension{}, "Raw")
+		if d := cmp.Diff(wantTriggerTemplate, *gotTriggerTemplate, ignoreTypeMetaField, ignoreRawTemplateField); d != "" {
+			t.Errorf("Unexpected TriggerTemplate: %s", diff.PrintWantGot(d))
+		}
+
+		gotPRTemplate := resourceTemplateToPipelineRun(t, gotTriggerTemplate.Spec.ResourceTemplates[0])
+		wantPRTemplate := resourceTemplateToPipelineRun(t, wantTriggerTemplate.Spec.ResourceTemplates[0])
+		if d := cmp.Diff(wantPRTemplate, gotPRTemplate); d != "" {
+			t.Errorf("Unexpected TriggerTemplate ResourceTemplate: %s", diff.PrintWantGot(d))
+		}
+
+		gotTriggerBinding, err := b.tektonClients.TriggerBindingClient.Get(ctx, w.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantTriggerBinding := v1alpha1.TriggerBinding{}
+		readYaml(t, wantTektonTriggerBinding, &wantTriggerBinding)
+
+		ignoreTypeMetaField = cmpopts.IgnoreFields(v1alpha1.TriggerBinding{}, "TypeMeta")
+		if d := cmp.Diff(wantTriggerBinding, *gotTriggerBinding, ignoreTypeMetaField); d != "" {
+			t.Errorf("Unexpected TriggerBinding: %s", diff.PrintWantGot(d))
+		}
+
+		gotEventListener, err := b.tektonClients.EventListenerClient.Get(ctx, w.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantEventListener := v1alpha1.EventListener{}
+		readYaml(t, wantTektonEventListener, &wantEventListener)
+
+		ignoreTypeMetaField = cmpopts.IgnoreFields(v1alpha1.EventListener{}, "TypeMeta")
+		if d := cmp.Diff(wantEventListener, *gotEventListener, ignoreTypeMetaField); d != "" {
+			t.Errorf("Unexpected Event Listener: %s", diff.PrintWantGot(d))
+		}
+	})
+
+	t.Run("existing listener", func(t *testing.T) {
+		ctx, b, logs, logsOutput := initBackend(t)
+
+		discardOutput := bytes.Buffer{}
+		discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
+		w := workflow.Workflow{}
+		readYaml(t, fuseMLWorkflow, &w)
+
+		err := b.CreateWorkflow(ctx, discardLogs, &w)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = b.CreateListener(ctx, discardLogs, w.Name, false)
+		if err != nil {
+			t.Fatalf("Failed to create listener for workflow %q: %s", w.Name, err)
+		}
+
+		url, err := b.CreateListener(ctx, logs, w.Name, false)
+		if err != nil {
+			t.Fatalf("Failed to create listener for workflow %q: %s", w.Name, err)
+		}
+
+		assertStrings(t, url, fmt.Sprintf("http://el-%s.%s.svc.cluster.local:8080", w.Name, b.namespace))
+
+		expectedLog := ""
+		assertStrings(t, logsOutput.String(), expectedLog)
+	})
+}
+
+func assertError(t testing.TB, got, want error) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("got error %q want %q", got, want)
+	}
+}
+
+func assertStrings(t testing.TB, got, want string) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func initBackend(t *testing.T) (context context.Context, backend *WorkflowBackend, logs *log.Logger, logsOutput *bytes.Buffer) {
+	t.Helper()
+
+	context, _ = rtesting.SetupFakeContext(t)
+	backend = fakeNewWorkflowBackend(context, t, testNamespace)
+
+	logsOutput = &bytes.Buffer{}
+	logs = log.New(logsOutput, "", 0)
+	return
+}
+
+func readYaml(t *testing.T, path string, obj interface{}) {
+	t.Helper()
+
+	wfFile, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read workflow file %s: %s", path, err)
+	}
+	err = yaml.Unmarshal(wfFile, &obj)
+	if err != nil {
+		t.Fatalf("Error unmarshiling workflow: %s", err)
+	}
+}
+
+func resourceTemplateToPipelineRun(t *testing.T, resourceTemplate v1alpha1.TriggerResourceTemplate) v1beta1.PipelineRun {
+	t.Helper()
+
+	pr := v1beta1.PipelineRun{}
+	err := json.Unmarshal(resourceTemplate.Raw, &pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pr
+}
+
+func newFakeClients(context context.Context, t *testing.T, namespace string) *clients {
+	t.Helper()
+
+	fc := &clients{}
+
+	pcs := fakepipelineclient.Get(context)
+	fc.PipelineClient = pcs.TektonV1beta1().Pipelines(namespace)
+	fc.PipelineRunClient = pcs.TektonV1beta1().PipelineRuns(namespace)
+
+	tcs := faketriggersclient.Get(context)
+	fc.TriggerTemplateClient = tcs.TriggersV1alpha1().TriggerTemplates(namespace)
+	fc.TriggerBindingClient = tcs.TriggersV1alpha1().TriggerBindings(namespace)
+	fc.EventListenerClient = tcs.TriggersV1alpha1().EventListeners(namespace)
+	return fc
+}
+
+func fakeNewWorkflowBackend(context context.Context, t *testing.T, namespace string) *WorkflowBackend {
+	t.Helper()
+
+	clients := newFakeClients(context, t, namespace)
+	return &WorkflowBackend{namespace, clients}
+}

--- a/pkg/core/tekton/testdata/tekton-event-listener.yaml
+++ b/pkg/core/tekton/testdata/tekton-event-listener.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: mlflow-sklearn-e2e
+  namespace: test-namespace
+spec:
+  serviceAccountName: staging-triggers-admin
+  triggers:
+    - bindings:
+        - ref: mlflow-sklearn-e2e
+      template:
+        ref: mlflow-sklearn-e2e

--- a/pkg/core/tekton/testdata/tekton-pipeline-run.yaml
+++ b/pkg/core/tekton/testdata/tekton-pipeline-run.yaml
@@ -1,0 +1,37 @@
+kind: PipelineRun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  generateName: fuseml-workspace-mlflow-app-01-
+  labels:
+    fuseml/codeset-name: mlflow-app-01
+    fuseml/codeset-version: main
+  namespace: "test-namespace"
+spec:
+  params:
+    - name: codeset-name
+      value: mlflow-app-01
+    - name: codeset-version
+      value: main
+    - name: predictor
+      value: auto
+  pipelineRef:
+    name: mlflow-sklearn-e2e
+  resources:
+    - name: source-repo
+      resourceSpec:
+        params:
+          - name: url
+            value: 'http://gitea.10.160.5.140.nip.io/workspace/mlflow-app-01.git'
+          - name: revision
+            value: main
+        type: git
+  serviceAccountName: staging-triggers-admin
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 2Gi

--- a/pkg/core/tekton/testdata/tekton-pipeline.yaml
+++ b/pkg/core/tekton/testdata/tekton-pipeline.yaml
@@ -1,0 +1,152 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    fuseml/generated-from: mlflow-sklearn-e2e
+  name: mlflow-sklearn-e2e
+  namespace: test-namespace
+spec:
+  description: >
+    End-to-end pipeline template that takes in an MLFlow compatible codeset,
+
+    runs the MLFlow project to train a model, then creates a KFServing
+    prediction
+
+    service that can be used to run predictions against the model."
+  params:
+    - description: Reference to the codeset (git project)
+      name: codeset-name
+    - default: "main"
+      description: Codeset version (git revision)
+      name: codeset-version
+    - default: auto
+      description: type of predictor engine
+      name: predictor
+  resources:
+    - name: source-repo
+      type: git
+  results:
+    - description: >-
+        The URL where the exposed prediction service endpoint can be contacted
+        to run predictions.
+      name: prediction-url
+      value: $(tasks.predictor.results.prediction-url)
+  tasks:
+    - name: clone
+      resources:
+        inputs:
+          - name: source-repo
+            resource: source-repo
+      taskRef:
+        name: clone
+      workspaces:
+        - name: source
+          workspace: source
+    - name: builder-prep
+      params:
+        - name: IMAGE
+          value: 'ghcr.io/fuseml/mlflow-dockerfile:0.1'
+        - name: DOCKERFILE
+          value: ''
+      runAfter:
+        - clone
+      taskRef:
+        name: builder-prep
+      workspaces:
+        - name: source
+          workspace: source
+    - name: builder
+      params:
+        - name: IMAGE
+          value: >-
+            registry.fuseml-registry/mlflow-builder/$(params.codeset-name):$(params.codeset-version)
+        - name: DOCKERFILE
+          value: $(tasks.builder-prep.results.DOCKERFILE-PATH)
+      runAfter:
+        - builder-prep
+      taskRef:
+        name: kaniko
+      workspaces:
+        - name: source
+          workspace: source
+    - name: trainer
+      params:
+        - name: IMAGE
+          value: >-
+            127.0.0.1:30500/mlflow-builder/$(params.codeset-name):$(params.codeset-version)
+      runAfter:
+        - builder
+      taskSpec:
+        metadata: {}
+        params:
+          - description: Name (reference) of the image to run
+            name: IMAGE
+        results:
+          - description: ''
+            name: mlflow-model-url
+        steps:
+          - command:
+              - run
+            env:
+              - name: TASK_RESULT
+                value: mlflow-model-url
+              - name: MLFLOW_TRACKING_URI
+                value: 'http://mlflow'
+              - name: MLFLOW_S3_ENDPOINT_URL
+                value: 'http://mlflow-minio:9000'
+              - name: AWS_ACCESS_KEY_ID
+                value: gABTE5DmmLgjJypJzGFs
+              - name: AWS_SECRET_ACCESS_KEY
+                value: uW1qiFS8DTFuACXCDrM7i5zLJXbbfXd6pReyntjn
+            image: $(params.IMAGE)
+            name: trainer
+            resources: {}
+            workingDir: /project
+        workspaces:
+          - mountPath: /project
+            name: source
+      workspaces:
+        - name: source
+          workspace: source
+    - name: predictor
+      params:
+        - name: model
+          value: $(tasks.trainer.results.mlflow-model-url)
+        - name: predictor
+          value: $(params.predictor)
+      runAfter:
+        - trainer
+      taskSpec:
+        metadata: {}
+        params:
+          - name: model
+          - name: predictor
+        results:
+          - description: ''
+            name: prediction-url
+        steps:
+          - command:
+              - run
+            env:
+              - name: FUSEML_MODEL
+                value: $(params.model)
+              - name: FUSEML_PREDICTOR
+                value: $(params.predictor)
+              - name: TASK_RESULT
+                value: prediction-url
+              - name: AWS_ACCESS_KEY_ID
+                value: gABTE5DmmLgjJypJzGFs
+              - name: AWS_SECRET_ACCESS_KEY
+                value: uW1qiFS8DTFuACXCDrM7i5zLJXbbfXd6pReyntjn
+            image: 'ghcr.io/fuseml/kfserving-predictor:0.1'
+            name: predictor
+            resources: {}
+            workingDir: /project
+        workspaces:
+          - mountPath: /project
+            name: source
+      workspaces:
+        - name: source
+          workspace: source
+  workspaces:
+    - name: source

--- a/pkg/core/tekton/testdata/tekton-trigger-binding.yaml
+++ b/pkg/core/tekton/testdata/tekton-trigger-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: mlflow-sklearn-e2e
+  namespace: "test-namespace"
+spec:
+  params:
+    - name: codeset-name
+      value: $(body.repository.name)
+    - name: codeset-url
+      value: $(body.repository.clone_url)
+    - name: codeset-version
+      value: '$(body.commits[0].id)'

--- a/pkg/core/tekton/testdata/tekton-trigger-template.yaml
+++ b/pkg/core/tekton/testdata/tekton-trigger-template.yaml
@@ -1,0 +1,54 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: mlflow-sklearn-e2e
+  namespace: "test-namespace"
+spec:
+  params:
+    - description: Reference to the codeset (git project)
+      name: codeset-name
+    - description: The codeset URL (git repository URL)
+      name: codeset-url
+    - default: main
+      description: Codeset version (git revision)
+      name: codeset-version
+    - default: auto
+      description: type of predictor engine
+      name: predictor
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: fuseml-$(tt.params.codeset-name)-
+        labels:
+          fuseml/codeset-name: $(tt.params.codeset-name)
+          fuseml/codeset-version: $(tt.params.codeset-version)
+      spec:
+        params:
+          - name: codeset-name
+            value: $(tt.params.codeset-name)
+          - name: codeset-version
+            value: $(tt.params.codeset-version)
+          - name: predictor
+            value: $(tt.params.predictor)
+        pipelineRef:
+          name: mlflow-sklearn-e2e
+        resources:
+          - name: source-repo
+            resourceSpec:
+              params:
+                - name: url
+                  value: $(tt.params.codeset-url)
+                - name: revision
+                  value: $(tt.params.codeset-version)
+              type: git
+        serviceAccountName: staging-triggers-admin
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 2Gi

--- a/pkg/core/tekton/testdata/workflow.yaml
+++ b/pkg/core/tekton/testdata/workflow.yaml
@@ -1,0 +1,62 @@
+name: mlflow-sklearn-e2e
+description: |
+  End-to-end pipeline template that takes in an MLFlow compatible codeset,
+  runs the MLFlow project to train a model, then creates a KFServing prediction
+  service that can be used to run predictions against the model."
+inputs:
+  - name: mlflow-codeset
+    description: an MLFlow compatible codeset
+    type: codeset
+  - name: predictor
+    description: type of predictor engine
+    type: string
+    default: auto
+outputs:
+  - name: prediction-url
+    description: "The URL where the exposed prediction service endpoint can be contacted to run predictions."
+    type: string
+steps:
+  - name: builder
+    image: ghcr.io/fuseml/mlflow-dockerfile:0.1
+    inputs:
+      - codeset:
+          name: '{{ inputs.mlflow-codeset }}'
+          path: /project
+    outputs:
+      - name: mlflow-env
+        image:
+          name: 'registry.fuseml-registry/mlflow-builder/{{ inputs.mlflow-codeset.name }}:{{ inputs.mlflow-codeset.version }}'
+  - name: trainer
+    image: '{{ steps.builder.outputs.mlflow-env }}'
+    inputs:
+      - codeset:
+          name: '{{ inputs.mlflow-codeset }}'
+          path: '/project'
+    outputs:
+      - name: mlflow-model-url
+    env:
+      - name: MLFLOW_TRACKING_URI
+        value: "http://mlflow"
+      - name: MLFLOW_S3_ENDPOINT_URL
+        value: "http://mlflow-minio:9000"
+      - name: AWS_ACCESS_KEY_ID
+        value: gABTE5DmmLgjJypJzGFs
+      - name: AWS_SECRET_ACCESS_KEY
+        value: uW1qiFS8DTFuACXCDrM7i5zLJXbbfXd6pReyntjn
+  - name: predictor
+    image: ghcr.io/fuseml/kfserving-predictor:0.1
+    inputs:
+      - name: model
+        value: '{{ steps.trainer.outputs.mlflow-model-url }}'
+      - name: predictor
+        value: '{{ inputs.predictor }}'
+      - codeset:
+          name: '{{ inputs.mlflow-codeset }}'
+          path: '/project'
+    outputs:
+      - name: prediction-url
+    env:
+      - name: AWS_ACCESS_KEY_ID
+        value: gABTE5DmmLgjJypJzGFs
+      - name: AWS_SECRET_ACCESS_KEY
+        value: uW1qiFS8DTFuACXCDrM7i5zLJXbbfXd6pReyntjn

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -14,7 +14,7 @@ import (
 
 // WorkflowBackend is the interface for the FuseML workflows
 type WorkflowBackend interface {
-	CreateListener(context.Context, *log.Logger, string) (string, error)
+	CreateListener(context.Context, *log.Logger, string, bool) (string, error)
 	CreateWorkflow(context.Context, *log.Logger, *workflow.Workflow) error
 	CreateWorkflowRun(context.Context, string, codeset.Codeset) error
 }
@@ -77,7 +77,7 @@ func (s *workflowsrvc) Assign(ctx context.Context, w *workflow.AssignPayload) (e
 		return err
 	}
 
-	url, err := s.backend.CreateListener(ctx, s.logger, w.WorkflowName)
+	url, err := s.backend.CreateListener(ctx, s.logger, w.WorkflowName, true)
 	if err != nil {
 		s.logger.Print(err)
 		return err


### PR DESCRIPTION
Add unit tests for the public tekton workflow backend functions.

This change also makes waiting for the event listener optional when creating it.