### PR TITLE
Codeset: do not create repository as private

### DIFF
--- a/pkg/core/gitea/client.go
+++ b/pkg/core/gitea/client.go
@@ -173,7 +173,7 @@ func (gac giteaAdminClient) CreateRepo(c *codeset.Codeset) error {
 	_, _, err = gac.giteaClient.CreateOrgRepo(c.Project, gitea.CreateRepoOption{
 		Name:          c.Name,
 		AutoInit:      true,
-		Private:       true,
+		Private:       false,
 		DefaultBranch: "main",
 		Description:   *c.Description,
 	})


### PR DESCRIPTION
User who creates the codeset might be different one than
user who is creating tekton pipeline (which needs to clone the code).
To prevent authentication issues, let's make the repository public.

See https://github.com/fuseml/fuseml/issues/89