### PR TITLE
Export Workflow name and namespace to the tekton tasks

### DIFF
--- a/pkg/core/tekton/constants.go
+++ b/pkg/core/tekton/constants.go
@@ -18,5 +18,6 @@ const (
 	imageParamName            = "IMAGE"
 	stepOutputVarName         = "TASK_RESULT"
 	inputsVarPrefix           = "FUSEML_"
+	globalEnvVarPrefix        = "FUSEML_ENV_"
 	stepDefaultCmd            = "run"
 )

--- a/pkg/core/tekton/testdata/tekton-pipeline.yaml
+++ b/pkg/core/tekton/testdata/tekton-pipeline.yaml
@@ -98,6 +98,10 @@ spec:
                 value: gABTE5DmmLgjJypJzGFs
               - name: AWS_SECRET_ACCESS_KEY
                 value: uW1qiFS8DTFuACXCDrM7i5zLJXbbfXd6pReyntjn
+              - name: FUSEML_ENV_WORKFLOW_NAMESPACE
+                value: test-namespace
+              - name: FUSEML_ENV_WORKFLOW_NAME
+                value: mlflow-sklearn-e2e
             image: $(params.IMAGE)
             name: trainer
             resources: {}
@@ -138,6 +142,10 @@ spec:
                 value: gABTE5DmmLgjJypJzGFs
               - name: AWS_SECRET_ACCESS_KEY
                 value: uW1qiFS8DTFuACXCDrM7i5zLJXbbfXd6pReyntjn
+              - name: FUSEML_ENV_WORKFLOW_NAMESPACE
+                value: test-namespace
+              - name: FUSEML_ENV_WORKFLOW_NAME
+                value: mlflow-sklearn-e2e
             image: 'ghcr.io/fuseml/kfserving-predictor:0.1'
             name: predictor
             resources: {}


### PR DESCRIPTION
So that containers of tekton tasks could use them.
See e.g. https://github.com/fuseml/extensions/pull/1


Part of https://github.com/fuseml/fuseml/issues/75