### PR TITLE
Add `Param`s to workflow assign

### DIFF
--- a/design/workflow.go
+++ b/design/workflow.go
@@ -93,7 +93,7 @@ var _ = Service("workflow", func() {
 		Description("Assigins a Workflow to a Codeset")
 
 		Payload(func() {
-			Field(1, "workflowName", String, "Name of the Workflow to be associated with the codeset", func() {
+			Field(1, "name", String, "Name of the Workflow to be associated with the codeset", func() {
 				Example("mlflow-sklearn-e2e")
 			})
 			Field(2, "codesetProject", String, "Project that hosts the codeset to assign the workflow to", func() {
@@ -102,7 +102,7 @@ var _ = Service("workflow", func() {
 			Field(3, "codesetName", String, "Codeset to assign the workflow to", func() {
 				Example("mlflow-project-001")
 			})
-			Required("workflowName", "codesetProject", "codesetName")
+			Required("name", "codesetProject", "codesetName")
 		})
 
 		Error("BadRequest", func() {
@@ -114,6 +114,9 @@ var _ = Service("workflow", func() {
 
 		HTTP(func() {
 			POST("/workflows/assign")
+			Param("name")
+			Param("codesetName")
+			Param("codesetProject")
 			Response(StatusCreated)
 			Response("BadRequest", StatusBadRequest)
 			Response("NotFound", StatusNotFound)

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -72,12 +72,12 @@ func (s *workflowsrvc) Assign(ctx context.Context, w *workflow.AssignPayload) (e
 		s.logger.Print(err)
 		return workflow.MakeNotFound(err)
 	}
-	if _, err = s.getWorkflow(ctx, w.WorkflowName); err != nil {
+	if _, err = s.getWorkflow(ctx, w.Name); err != nil {
 		s.logger.Print(err)
 		return err
 	}
 
-	url, err := s.backend.CreateListener(ctx, s.logger, w.WorkflowName, true)
+	url, err := s.backend.CreateListener(ctx, s.logger, w.Name, true)
 	if err != nil {
 		s.logger.Print(err)
 		return err
@@ -89,7 +89,7 @@ func (s *workflowsrvc) Assign(ctx context.Context, w *workflow.AssignPayload) (e
 		return err
 	}
 
-	err = s.backend.CreateWorkflowRun(ctx, w.WorkflowName, *codeset)
+	err = s.backend.CreateWorkflowRun(ctx, w.Name, *codeset)
 	if err != nil {
 		s.logger.Print(err)
 		return err


### PR DESCRIPTION
Makes using the CLI easier as it accepts passing the parameters
directly instead of building a body when assigning workflows to
codesets.