### PR TITLE
Customized goa CLI code generator 

### DIFF
--- a/cmd/fuseml_core-cli/http.go
+++ b/cmd/fuseml_core-cli/http.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	cli "github.com/fuseml/fuseml-core/gen/http/cli/fuseml_core"
-	"github.com/goccy/go-yaml"
+	yaml "github.com/goccy/go-yaml"
 	goahttp "goa.design/goa/v3/http"
 	goa "goa.design/goa/v3/pkg"
 )
@@ -54,7 +54,7 @@ func responseDecoder(resp *http.Response) goahttp.Decoder {
 	case ct == "", ct == "application/x-yaml", ct == "text/x-yaml":
 		fallthrough
 	case strings.HasSuffix(ct, "+yaml"):
-		return yaml.NewDecoder(resp.Body)
+		return yaml.NewDecoder(resp.Body, yaml.Strict())
 	default:
 		return goahttp.ResponseDecoder(resp)
 	}

--- a/cmd/fuseml_core-cli/main.go
+++ b/cmd/fuseml_core-cli/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/goccy/go-yaml"
 
 	codeset "github.com/fuseml/fuseml-core/gen/codeset"
 	gitc "github.com/fuseml/fuseml-core/pkg/client"
@@ -92,7 +93,7 @@ func main() {
 	}
 
 	if data != nil {
-		m, _ := json.MarshalIndent(data, "", "    ")
+		m, _ := yaml.Marshal(data)
 		fmt.Println(string(m))
 	}
 	// Pushing the code must be done from client, before passing the request to the server

--- a/design/api.go
+++ b/design/api.go
@@ -1,6 +1,7 @@
 package design
 
 import (
+	_ "github.com/fuseml/fuseml-core/design/cli"
 	. "goa.design/goa/v3/dsl"
 )
 

--- a/design/cli/cli.go
+++ b/design/cli/cli.go
@@ -1,0 +1,735 @@
+// Package cli contains helpers used by transport-specific command-line client
+// generators for parsing the command-line flags to identify the service and
+// the method to make a request along with the request payload to be sent.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/codegen/service"
+	"goa.design/goa/v3/expr"
+)
+
+type (
+	// CommandData contains the data needed to render a command.
+	CommandData struct {
+		// Name of command e.g. "cellar-storage"
+		Name string
+		// VarName is the name of the command variable e.g.
+		// "cellarStorage"
+		VarName string
+		// Description is the help text.
+		Description string
+		// Subcommands is the list of endpoint commands.
+		Subcommands []*SubcommandData
+		// Example is a valid command invocation, starting with the
+		// command name.
+		Example string
+		// PkgName is the service HTTP client package import name,
+		// e.g. "storagec".
+		PkgName string
+	}
+
+	// SubcommandData contains the data needed to render a sub-command.
+	SubcommandData struct {
+		// Name is the sub-command name e.g. "add"
+		Name string
+		// FullName is the sub-command full name e.g. "storageAdd"
+		FullName string
+		// Description is the help text.
+		Description string
+		// Flags is the list of flags supported by the subcommand.
+		Flags []*FlagData
+		// MethodVarName is the endpoint method name, e.g. "Add"
+		MethodVarName string
+		// BuildFunction contains the data to generate a payload builder function
+		// if any. Exclusive with Conversion.
+		BuildFunction *BuildFunctionData
+		// Conversion contains the flag value to payload conversion function if
+		// any. Exclusive with BuildFunction.
+		Conversion string
+		// Example is a valid command invocation, starting with the command name.
+		Example string
+	}
+
+	// FlagData contains the data needed to render a command-line flag.
+	FlagData struct {
+		// Name is the name of the flag, e.g. "list-vintage"
+		Name string
+		// VarName is the name of the flag variable, e.g. "listVintage"
+		VarName string
+		// Type is the type of the flag, e.g. INT
+		Type string
+		// FullName is the flag full name e.g. "storageAddVintage"
+		FullName string
+		// Description is the flag help text.
+		Description string
+		// Required is true if the flag is required.
+		Required bool
+		// Example returns a JSON serialized example value.
+		Example string
+		// Default returns the default value if any.
+		Default interface{}
+	}
+
+	// BuildFunctionData contains the data needed to generate a constructor
+	// function that builds a service method payload type from the command-line
+	// flags.
+	BuildFunctionData struct {
+		// Name is the build payload function name.
+		Name string
+		// Description describes the payload function.
+		Description string
+		// ActualParams is the list of passed build function parameters.
+		ActualParams []string
+		// FormalParams is the list of build function formal parameter
+		// names.
+		FormalParams []string
+		// ServiceName is the name of the service.
+		ServiceName string
+		// MethodName is the name of the method.
+		MethodName string
+		// ResultType is the fully qualified payload type name.
+		ResultType string
+		// Fields describes the payload fields.
+		Fields []*FieldData
+		// PayloadInit contains the data needed to render the function
+		// body.
+		PayloadInit *PayloadInitData
+		// CheckErr is true if the payload initialization code requires an
+		// "err error" variable that must be checked.
+		CheckErr bool
+	}
+
+	// FieldData contains the data needed to generate the code that initializes a
+	// field in the method payload type.
+	FieldData struct {
+		// Name is the field name, e.g. "Vintage"
+		Name string
+		// VarName is the name of the local variable holding the field
+		// value, e.g. "vintage"
+		VarName string
+		// TypeRef is the reference to the type.
+		TypeRef string
+		// Init is the code initializing the variable.
+		Init string
+	}
+
+	// PayloadInitData contains the data needed to generate a constructor
+	// function that initializes a service method payload type from the
+	// command-ling arguments.
+	PayloadInitData struct {
+		// Code is the payload initialization code.
+		Code string
+		// ReturnTypeAttribute if non-empty returns an attribute in the payload
+		// type that describes the shape of the method payload.
+		ReturnTypeAttribute string
+		// ReturnTypeAttributePointer is true if the return type attribute
+		// generated struct field holds a pointer
+		ReturnTypeAttributePointer bool
+		// ReturnIsStruct if true indicates that the method payload is an object.
+		ReturnIsStruct bool
+		// ReturnTypeName is the fully-qualified name of the payload.
+		ReturnTypeName string
+		// ReturnTypePkg is the package name where the payload is present.
+		ReturnTypePkg string
+		// Args is the list of arguments for the constructor.
+		Args []*codegen.InitArgData
+	}
+)
+
+// BuildCommandData builds the data needed by CLI code generators to render the
+// parsing of the service command.
+func BuildCommandData(data *service.Data) *CommandData {
+	description := data.Description
+	if description == "" {
+		description = fmt.Sprintf("Make requests to the %q service", data.Name)
+	}
+	return &CommandData{
+		Name:        codegen.KebabCase(data.Name),
+		VarName:     codegen.Goify(data.Name, false),
+		Description: description,
+		PkgName:     data.PkgName + "c",
+	}
+}
+
+// BuildSubcommandData builds the data needed by CLI code generators to render
+// the CLI parsing of the service sub-command.
+func BuildSubcommandData(svcName string, m *service.MethodData, buildFunction *BuildFunctionData, flags []*FlagData) *SubcommandData {
+	var (
+		name        string
+		fullName    string
+		description string
+
+		conversion string
+	)
+	{
+		en := m.Name
+		name = codegen.KebabCase(en)
+		fullName = goifyTerms(svcName, en)
+		description = m.Description
+		if description == "" {
+			description = fmt.Sprintf("Make request to the %q endpoint", m.Name)
+		}
+
+		if buildFunction == nil && len(flags) > 0 {
+			// No build function, just convert the arg to the body type
+			var convPre, convSuff string
+			target := "data"
+			if flagType(m.Payload) == "JSON" {
+				target = "val"
+				convPre = fmt.Sprintf("var val %s\n", m.Payload)
+				convSuff = "\ndata = val"
+			}
+			conv, _, check := conversionCode(
+				"*"+flags[0].FullName+"Flag",
+				target,
+				m.Payload,
+				false,
+			)
+			conversion = convPre + conv + convSuff
+			if check {
+				conversion = "var err error\n" + conversion
+				conversion += "\nif err != nil {\n"
+				if flagType(m.Payload) == "JSON" {
+					conversion += fmt.Sprintf(`return nil, nil, fmt.Errorf("invalid JSON for %s, \nerror: %%s, \nexample of valid JSON:\n%%s", err, %q)`,
+						flags[0].FullName+"Flag", flags[0].Example)
+				} else {
+					conversion += fmt.Sprintf(`return nil, nil, fmt.Errorf("invalid value for %s, must be %s")`,
+						flags[0].FullName+"Flag", flags[0].Type)
+				}
+				conversion += "\n}"
+			}
+		}
+	}
+	sub := &SubcommandData{
+		Name:          name,
+		FullName:      fullName,
+		Description:   description,
+		Flags:         flags,
+		MethodVarName: m.VarName,
+		BuildFunction: buildFunction,
+		Conversion:    conversion,
+	}
+	generateExample(sub, svcName)
+
+	return sub
+}
+
+// UsageCommands builds a section template that generates a help text showing
+// the list of allowed commands and sub-commands.
+func UsageCommands(data []*CommandData) *codegen.SectionTemplate {
+	usages := make([]string, len(data))
+	for i, cmd := range data {
+		subs := make([]string, len(cmd.Subcommands))
+		for i, s := range cmd.Subcommands {
+			subs[i] = s.Name
+		}
+		var lp, rp string
+		if len(subs) > 1 {
+			lp = "("
+			rp = ")"
+		}
+		usages[i] = fmt.Sprintf("%s %s%s%s", cmd.Name, lp, strings.Join(subs, "|"), rp)
+	}
+
+	return &codegen.SectionTemplate{Source: usageT, Data: usages}
+}
+
+// UsageExamples builds a section template that generates a help text showing
+// a valid invocation of the CLI tool.
+func UsageExamples(data []*CommandData) *codegen.SectionTemplate {
+	var examples []string
+	for i, cmd := range data {
+		if i < 5 {
+			examples = append(examples, cmd.Example)
+		}
+	}
+
+	return &codegen.SectionTemplate{Source: exampleT, Data: examples}
+}
+
+// FlagsCode returns a string containing the code that parses the command-line
+// flags to infer the command (service), sub-command (method), and the
+// arguments (method payload) invoked by the tool. It panics if any error
+// occurs during the generation of flag parsing code.
+func FlagsCode(data []*CommandData) string {
+	section := codegen.SectionTemplate{
+		Name:    "parse-endpoint-flags",
+		Source:  parseFlagsT,
+		Data:    data,
+		FuncMap: map[string]interface{}{"printDescription": printDescription},
+	}
+	var flagsCode bytes.Buffer
+	err := section.Write(&flagsCode)
+	if err != nil {
+		panic(err)
+	}
+
+	return flagsCode.String()
+}
+
+// CommandUsage builds the section templates that can be used to generate the
+// endpoint command usage code.
+func CommandUsage(data *CommandData) *codegen.SectionTemplate {
+	return &codegen.SectionTemplate{
+		Name:    "cli-command-usage",
+		Source:  commandUsageT,
+		Data:    data,
+		FuncMap: map[string]interface{}{"printDescription": printDescription},
+	}
+}
+
+// PayloadBuilderSection builds the section template that can be used to
+// generate the payload builder code.
+func PayloadBuilderSection(buildFunction *BuildFunctionData) *codegen.SectionTemplate {
+	return &codegen.SectionTemplate{
+		Name:   "cli-build-payload",
+		Source: buildPayloadT,
+		Data:   buildFunction,
+		FuncMap: map[string]interface{}{
+			"fieldCode": fieldCode,
+		},
+	}
+}
+
+// NewFlagData creates a new FlagData from the given argument attributes.
+//
+// svcn is the service name
+// en is the endpoint name
+// name is the flag name
+// typeName is the flag type
+// description is the flag description
+// required determines if the flag is required
+// example is an example value for the flag
+//
+func NewFlagData(svcn, en, name, typeName, description string, required bool, example, def interface{}) *FlagData {
+	ex := jsonExample(example)
+	fn := goifyTerms(svcn, en, name)
+	return &FlagData{
+		Name:        codegen.KebabCase(name),
+		VarName:     codegen.Goify(name, false),
+		Type:        flagType(typeName),
+		FullName:    fn,
+		Description: description,
+		Required:    required,
+		Example:     ex,
+		Default:     def,
+	}
+}
+
+// FieldLoadCode returns the code used in the build payload function that
+// initializes one of the payload object fields. It returns the initialization
+// code and a boolean indicating whether the code requires an "err" variable.
+func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultValue interface{}, payload expr.DataType) (string, bool) {
+	var (
+		code    string
+		declErr bool
+		startIf string
+		endIf   string
+		rval    string
+	)
+	{
+		if !f.Required {
+			startIf = fmt.Sprintf("if %s != \"\" {\n", f.FullName)
+			endIf = "\n}"
+		}
+		if expr.IsPrimitive(payload) {
+			switch payload {
+			case expr.Boolean:
+				rval = "false"
+			case expr.String:
+				rval = "\"\""
+			case expr.Bytes, expr.Any:
+				rval = "nil"
+			default:
+				rval = "0"
+			}
+		} else {
+			rval = "nil"
+		}
+		if argTypeName == codegen.GoNativeTypeName(expr.String) {
+			ref := "&"
+			if f.Required || defaultValue != nil {
+				ref = ""
+			}
+			code = argName + " = " + ref + f.FullName
+			declErr = validate != ""
+		} else {
+			var checkErr bool
+			code, declErr, checkErr = conversionCode(f.FullName, argName, argTypeName, !f.Required && defaultValue == nil)
+			if checkErr {
+				code += "\nif err != nil {\n"
+				if flagType(argTypeName) == "JSON" {
+					code += fmt.Sprintf(`return %v, fmt.Errorf("invalid JSON for %s, \nerror: %%s, \nexample of valid JSON:\n%%s", err, %q)`,
+						rval, argName, f.Example)
+				} else {
+					code += fmt.Sprintf(`return %v, fmt.Errorf("invalid value for %s, must be %s")`,
+						rval, argName, f.Type)
+				}
+				code += "\n}"
+			}
+		}
+		if validate != "" {
+			code += "\n" + validate + "\n" + fmt.Sprintf("if err != nil {\n\treturn %v, err\n}", rval)
+		}
+	}
+	return fmt.Sprintf("%s%s%s", startIf, code, endIf), declErr
+}
+
+// flagType calculates the type of a flag
+func flagType(tname string) string {
+	switch tname {
+	case boolN, intN, int32N, int64N, uintN, uint32N, uint64N, float32N, float64N, stringN:
+		return strings.ToUpper(tname)
+	case bytesN:
+		return "STRING"
+	default: // Any, Array, Map, Object, User
+		return "JSON"
+	}
+}
+
+// jsonExample generates a json example
+func jsonExample(v interface{}) string {
+	// In JSON, keys must be a string. But goa allows map keys to be anything.
+	r := reflect.ValueOf(v)
+	if r.Kind() == reflect.Map {
+		keys := r.MapKeys()
+		if keys[0].Kind() != reflect.String {
+			a := make(map[string]interface{}, len(keys))
+			var kstr string
+			for _, k := range keys {
+				switch t := k.Interface().(type) {
+				case bool:
+					kstr = strconv.FormatBool(t)
+				case int32:
+					kstr = strconv.FormatInt(int64(t), 10)
+				case int64:
+					kstr = strconv.FormatInt(t, 10)
+				case int:
+					kstr = strconv.Itoa(t)
+				case float32:
+					kstr = strconv.FormatFloat(float64(t), 'f', -1, 32)
+				case float64:
+					kstr = strconv.FormatFloat(t, 'f', -1, 64)
+				default:
+					kstr = k.String()
+				}
+				a[kstr] = r.MapIndex(k).Interface()
+			}
+			v = a
+		}
+	}
+	b, err := json.MarshalIndent(v, "   ", "   ")
+	ex := "?"
+	if err == nil {
+		ex = string(b)
+	}
+	if strings.Contains(ex, "\n") {
+		ex = "'" + strings.Replace(ex, "'", "\\'", -1) + "'"
+	}
+	return ex
+}
+
+var (
+	boolN    = codegen.GoNativeTypeName(expr.Boolean)
+	intN     = codegen.GoNativeTypeName(expr.Int)
+	int32N   = codegen.GoNativeTypeName(expr.Int32)
+	int64N   = codegen.GoNativeTypeName(expr.Int64)
+	uintN    = codegen.GoNativeTypeName(expr.UInt)
+	uint32N  = codegen.GoNativeTypeName(expr.UInt32)
+	uint64N  = codegen.GoNativeTypeName(expr.UInt64)
+	float32N = codegen.GoNativeTypeName(expr.Float32)
+	float64N = codegen.GoNativeTypeName(expr.Float64)
+	stringN  = codegen.GoNativeTypeName(expr.String)
+	bytesN   = codegen.GoNativeTypeName(expr.Bytes)
+)
+
+// conversionCode produces the code that converts the string contained in the
+// variable named from to the value stored in the variable "to" of type
+// typeName. The second return value indicates whether the "err" variable must
+// be declared prior to the conversion code being rendered. The last return
+// value indicates whether the generated code can produce errors (i.e.
+// initialize the err variable).
+func conversionCode(from, to, typeName string, pointer bool) (string, bool, bool) {
+	var (
+		parse string
+		cast  string
+
+		target   = to
+		needCast = typeName != stringN && typeName != bytesN && flagType(typeName) != "JSON"
+		declErr  = true
+		checkErr = true
+		decl     = ""
+	)
+	if needCast && pointer {
+		target = "val"
+		decl = ":"
+	}
+	switch typeName {
+	case boolN:
+		if pointer {
+			parse = fmt.Sprintf("var %s bool\n", target)
+		}
+		parse += fmt.Sprintf("%s, err = strconv.ParseBool(%s)", target, from)
+	case intN:
+		parse = fmt.Sprintf("var v int64\nv, err = strconv.ParseInt(%s, 10, 64)", from)
+		cast = fmt.Sprintf("%s %s= int(v)", target, decl)
+	case int32N:
+		parse = fmt.Sprintf("var v int64\nv, err = strconv.ParseInt(%s, 10, 32)", from)
+		cast = fmt.Sprintf("%s %s= int32(v)", target, decl)
+	case int64N:
+		parse = fmt.Sprintf("%s, err %s= strconv.ParseInt(%s, 10, 64)", target, decl, from)
+		declErr = decl == ""
+	case uintN:
+		parse = fmt.Sprintf("var v uint64\nv, err = strconv.ParseUint(%s, 10, 64)", from)
+		cast = fmt.Sprintf("%s %s= uint(v)", target, decl)
+	case uint32N:
+		parse = fmt.Sprintf("var v uint64\nv, err = strconv.ParseUint(%s, 10, 32)", from)
+		cast = fmt.Sprintf("%s %s= uint32(v)", target, decl)
+	case uint64N:
+		parse = fmt.Sprintf("%s, err %s= strconv.ParseUint(%s, 10, 64)", target, decl, from)
+		declErr = decl == ""
+	case float32N:
+		parse = fmt.Sprintf("var v float64\nv, err = strconv.ParseFloat(%s, 32)", from)
+		cast = fmt.Sprintf("%s %s= float32(v)", target, decl)
+	case float64N:
+		parse = fmt.Sprintf("%s, err %s= strconv.ParseFloat(%s, 64)", target, decl, from)
+		declErr = decl == ""
+	case stringN:
+		parse = fmt.Sprintf("%s %s= %s", target, decl, from)
+		declErr = false
+		checkErr = false
+	case bytesN:
+		parse = fmt.Sprintf("%s %s= []byte(%s)", target, decl, from)
+		declErr = false
+		checkErr = false
+	default:
+		parse = fmt.Sprintf("err = json.Unmarshal([]byte(%s), &%s)", from, target)
+	}
+	if !needCast {
+		return parse, declErr, checkErr
+	}
+	if cast != "" {
+		parse = parse + "\n" + cast
+	}
+	if to != target {
+		ref := ""
+		if pointer {
+			ref = "&"
+		}
+		parse = parse + fmt.Sprintf("\n%s = %s%s", to, ref, target)
+	}
+	return parse, declErr, checkErr
+}
+
+// goifyTerms makes valid go identifiers out of the supplied terms
+func goifyTerms(terms ...string) string {
+	res := codegen.Goify(terms[0], false)
+	if len(terms) == 1 {
+		return res
+	}
+	for _, t := range terms[1:] {
+		res += codegen.Goify(t, true)
+	}
+	return res
+}
+
+func printDescription(desc string) string {
+	res := strings.Replace(desc, "`", "`+\"`\"+`", -1)
+	res = strings.Replace(res, "\n", "\n\t", -1)
+	return res
+}
+
+func generateExample(sub *SubcommandData, svc string) {
+	ex := codegen.KebabCase(svc) + " " + codegen.KebabCase(sub.Name)
+	for _, f := range sub.Flags {
+		ex += " --" + f.Name + " " + f.Example
+	}
+	sub.Example = ex
+}
+
+// fieldCode generates code to initialize the data structures fields
+// from the given args. It is used only in templates.
+func fieldCode(init *PayloadInitData) string {
+	varn := "res"
+	if init.ReturnTypeAttribute == "" {
+		varn = "v"
+	}
+	// We can ignore the transform helpers as there won't be any generated
+	// because the args cannot be user types.
+	c, _, err := codegen.InitStructFields(init.Args, init.ReturnTypeName, varn, "", init.ReturnTypePkg, init.Code == "")
+	if err != nil {
+		panic(err) //bug
+	}
+	return c
+}
+
+// input: []string
+const usageT = `// UsageCommands returns the set of commands and sub-commands using the format
+//
+//    command (subcommand1|subcommand2|...)
+//
+func UsageCommands() string {
+	return ` + "`" + `{{ range . }}{{ . }}
+{{ end }}` + "`" + `
+}
+`
+
+// input: []string
+const exampleT = `// UsageExamples produces an example of a valid invocation of the CLI tool.
+func UsageExamples() string {
+	return {{ range . }}os.Args[0] + ` + "`" + ` {{ . }}` + "`" + ` + "\n" +
+	{{ end }}""
+}
+`
+
+// input: []commandData
+const parseFlagsT = `var (
+		{{- range . }}
+		{{ .VarName }}Flags = flag.NewFlagSet("{{ .Name }}", flag.ContinueOnError)
+		{{ range .Subcommands }}
+		{{ .FullName }}Flags = flag.NewFlagSet("{{ .Name }}", flag.ExitOnError)
+		{{- $sub := . }}
+		{{- range .Flags }}
+		{{ .FullName }}Flag = {{ $sub.FullName }}Flags.String("{{ .Name }}", "{{ if .Default }}{{ .Default }}{{ else if .Required }}REQUIRED{{ end }}", {{ printf "%q" .Description }})
+		{{- end }}
+		{{ end }}
+		{{- end }}
+	)
+	{{ range . -}}
+	{{ $cmd := . -}}
+	{{ .VarName }}Flags.Usage = {{ .VarName }}Usage
+	{{ range .Subcommands -}}
+	{{ .FullName }}Flags.Usage = {{ .FullName }}Usage
+	{{ end }}
+	{{ end }}
+	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+		return nil, nil, err
+	}
+
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
+		return nil, nil, fmt.Errorf("not enough arguments")
+	}
+
+	var (
+		svcn string
+		svcf *flag.FlagSet
+	)
+	{
+		svcn = flag.Arg(0)
+		switch svcn {
+	{{- range . }}
+		case "{{ .Name }}":
+			svcf = {{ .VarName }}Flags
+	{{- end }}
+		default:
+			return nil, nil, fmt.Errorf("unknown service %q", svcn)
+		}
+	}
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
+		return nil, nil, err
+	}
+
+	var (
+		epn string
+		epf *flag.FlagSet
+	)
+	{
+		epn = svcf.Arg(0)
+		switch svcn {
+	{{- range . }}
+		case "{{ .Name }}":
+			switch epn {
+		{{- range .Subcommands }}
+			case "{{ .Name }}":
+				epf = {{ .FullName }}Flags
+		{{ end }}
+			}
+	{{ end }}
+		}
+	}
+	if epf == nil {
+		return nil, nil, fmt.Errorf("unknown %q endpoint %q", svcn, epn)
+	}
+
+	// Parse endpoint flags if any
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
+			return nil, nil, err
+		}
+	}
+`
+
+// input: commandData
+const commandUsageT = `{{ printf "%sUsage displays the usage of the %s command and its subcommands." .Name .Name | comment }}
+func {{ .VarName }}Usage() {
+	fmt.Fprintf(os.Stderr, ` + "`" + `{{ printDescription .Description }}
+Usage:
+    %s [globalflags] {{ .Name }} COMMAND [flags]
+
+COMMAND:
+    {{- range .Subcommands }}
+    {{ .Name }}: {{ printDescription .Description }}
+    {{- end }}
+
+Additional help:
+    %s {{ .Name }} COMMAND --help
+` + "`" + `, os.Args[0], os.Args[0])
+}
+
+{{- range .Subcommands }}
+func {{ .FullName }}Usage() {
+	fmt.Fprintf(os.Stderr, ` + "`" + `%s [flags] {{ $.Name }} {{ .Name }}{{range .Flags }} -{{ .Name }} {{ .Type }}{{ end }}
+
+{{ printDescription .Description}}
+	{{- range .Flags }}
+    -{{ .Name }} {{ .Type }}: {{ .Description }}
+	{{- end }}
+
+Example:
+    ` + "`+os.Args[0]+" + "`" + ` {{ .Example }}
+` + "`" + `, os.Args[0])
+}
+{{ end }}
+`
+
+// input: buildFunctionData
+const buildPayloadT = `{{ printf "%s builds the payload for the %s %s endpoint from CLI flags." .Name .ServiceName .MethodName | comment }}
+func {{ .Name }}({{ range .FormalParams }}{{ . }} string, {{ end }}) ({{ .ResultType }}, error) {
+{{- if .CheckErr }}
+	var err error
+{{- end }}
+{{- range .Fields }}
+	{{- if .VarName }}
+		var {{ .VarName }} {{ .TypeRef }}
+		{
+			{{ .Init }}
+		}
+	{{- end }}
+{{- end }}
+{{- with .PayloadInit }}
+	{{- if .Code }}
+		{{ .Code }}
+		{{- if .ReturnTypeAttribute }}
+			res := &{{ .ReturnTypeName }}{
+				{{ .ReturnTypeAttribute }}: {{ if .ReturnTypeAttributePointer }}&{{ end }}v,
+			}
+		{{- end }}
+	{{- end }}
+	{{- if .ReturnIsStruct }}
+		{{- if not .Code }}
+		{{ if .ReturnTypeAttribute }}res{{ else }}v{{ end }} := &{{ .ReturnTypeName }}{}
+		{{- end }}
+		{{ fieldCode . }}
+	{{- end }}
+	return {{ if .ReturnTypeAttribute }}res{{ else }}v{{ end }}, nil
+{{- end }}
+}
+`

--- a/design/cli/cli.go
+++ b/design/cli/cli.go
@@ -440,42 +440,15 @@ func jsonExample(v interface{}) string {
 
 // yamlExample generates a yaml example
 func yamlExample(v interface{}) string {
-	// In YAML, keys must be a string. But goa allows map keys to be anything.
+	// Scalars are represented on a single line
 	r := reflect.ValueOf(v)
-	if r.Kind() == reflect.Map {
-		keys := r.MapKeys()
-		if keys[0].Kind() != reflect.String {
-			a := make(map[string]interface{}, len(keys))
-			var kstr string
-			for _, k := range keys {
-				switch t := k.Interface().(type) {
-				case bool:
-					kstr = strconv.FormatBool(t)
-				case int32:
-					kstr = strconv.FormatInt(int64(t), 10)
-				case int64:
-					kstr = strconv.FormatInt(t, 10)
-				case int:
-					kstr = strconv.Itoa(t)
-				case float32:
-					kstr = strconv.FormatFloat(float64(t), 'f', -1, 32)
-				case float64:
-					kstr = strconv.FormatFloat(t, 'f', -1, 64)
-				default:
-					kstr = k.String()
-				}
-				a[kstr] = r.MapIndex(k).Interface()
-			}
-			v = a
-		}
+	if r.Kind() != reflect.Map && r.Kind() != reflect.Array {
+		return fmt.Sprintf("\"%s\"", r)
 	}
 	b, err := yaml.Marshal(v)
 	ex := "?"
 	if err == nil {
-		ex = string(b)
-	}
-	if strings.Contains(ex, "\n") {
-		ex = "'" + strings.Replace(ex, "'", "\\'", -1) + "'"
+		ex = "\"" + string(b) + "\""
 	}
 	return ex
 }

--- a/design/cli/cli.go
+++ b/design/cli/cli.go
@@ -554,7 +554,7 @@ func conversionCode(from, to, typeName string, pointer bool) (string, bool, bool
 		declErr = false
 		checkErr = false
 	default:
-		parse = fmt.Sprintf("err = yaml.Unmarshal([]byte(%s), &%s)", from, target)
+		parse = fmt.Sprintf("err = yaml.UnmarshalWithOptions([]byte(%s), &%s, yaml.Strict())", from, target)
 	}
 	if !needCast {
 		return parse, declErr, checkErr
@@ -728,12 +728,13 @@ Additional help:
 }
 
 {{- range .Subcommands }}
+{{ printf "%sUsage displays the usage of the %s %s subcommand." .FullName $.Name .Name | comment }}
 func {{ .FullName }}Usage() {
-	fmt.Fprintf(os.Stderr, ` + "`" + `%s [flags] {{ $.Name }} {{ .Name }}{{range .Flags }} -{{ .Name }} {{ .Type }}{{ end }}
+	fmt.Fprintf(os.Stderr, ` + "`" + `%s [flags] {{ $.Name }} {{ .Name }}{{range .Flags }} --{{ .Name }} {{ .Type }}{{ end }}
 
 {{ printDescription .Description}}
 	{{- range .Flags }}
-    -{{ .Name }} {{ .Type }}: {{ .Description }}
+    --{{ .Name }} {{ .Type }}: {{ .Description }}
 	{{- end }}
 
 Example:

--- a/design/cli/http.go
+++ b/design/cli/http.go
@@ -1,0 +1,385 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/eval"
+	"goa.design/goa/v3/expr"
+	http "goa.design/goa/v3/http/codegen"
+)
+
+// init registers the plugin generator function.
+func init() {
+	codegen.RegisterPlugin("fuseml-cli", "gen", nil, Generate)
+}
+
+// commandData wraps the common CommandData and adds HTTP-specific fields.
+type commandData struct {
+	*CommandData
+	// Subcommands is the list of endpoint commands.
+	Subcommands []*subcommandData
+	// NeedStream if true initializes the websocket dialer.
+	NeedStream bool
+}
+
+// commandData wraps the common SubcommandData and adds HTTP-specific fields.
+type subcommandData struct {
+	*SubcommandData
+	// MultipartFuncName is the name of the function used to render a multipart
+	// request encoder.
+	MultipartFuncName string
+	// MultipartFuncName is the name of the variabl used to render a multipart
+	// request encoder.
+	MultipartVarName string
+	// StreamFlag is the flag used to identify the file to be streamed when
+	// the endpoint uses SkipRequestBodyEncodeDecode.
+	StreamFlag *FlagData
+	// BuildStreamPayload is the name of the generated function that builds the
+	// request data structure that wraps the payload and the file stream for
+	// endpoints that use SkipRequestBodyEncodeDecode.
+	BuildStreamPayload string
+}
+
+// Generate produces the fuseml modified CLI code files
+func Generate(genpkg string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
+	for _, root := range roots {
+		if root, ok := root.(*expr.RootExpr); ok {
+			fuseml_cli_files := ClientCLIFiles(genpkg, root)
+			for _, file := range files {
+				if f, isModified := fuseml_cli_files[file.Path]; isModified {
+					*file = *f
+					fmt.Printf("FuseML overriden file: %s\n", file.Path)
+				}
+				// fmt.Printf("FUSEML: file %s\n", file.Path)
+				// for _, template := range file.SectionTemplates {
+				// 	fmt.Printf("FUSEML:     template %s\n", template.Name)
+				// 	fmt.Printf("FUSEML:         source %s\n", template.Source)
+				// 	for fnc, _ := range template.FuncMap {
+				// 		fmt.Printf("FUSEML:         function %s\n", fnc)
+				// 	}
+
+				// }
+			}
+		}
+	}
+	return files, nil
+}
+
+// ClientCLIFiles returns the client HTTP CLI support files mapped according to their full path.
+func ClientCLIFiles(genpkg string, root *expr.RootExpr) map[string]*codegen.File {
+	if len(root.API.HTTP.Services) == 0 {
+		return nil
+	}
+	var (
+		data []*commandData
+		svcs []*expr.HTTPServiceExpr
+	)
+	for _, svc := range root.API.HTTP.Services {
+		sd := http.HTTPServices.Get(svc.Name())
+		if len(sd.Endpoints) > 0 {
+			command := &commandData{
+				CommandData: BuildCommandData(sd.Service),
+				NeedStream:  false, // hasWebSocket(sd),
+			}
+
+			for _, e := range sd.Endpoints {
+				sub := buildSubcommandData(sd, e)
+				command.Subcommands = append(command.Subcommands, sub)
+				command.CommandData.Subcommands = append(command.CommandData.Subcommands, sub.SubcommandData)
+			}
+
+			command.Example = command.Subcommands[0].Example
+
+			data = append(data, command)
+			svcs = append(svcs, svc)
+		}
+	}
+	files := make(map[string]*codegen.File)
+	for _, svr := range root.API.Servers {
+		file := endpointParser(genpkg, root, svr, data)
+		files[file.Path] = file
+	}
+	for i, svc := range svcs {
+		file := payloadBuilders(genpkg, svc, data[i].CommandData)
+		files[file.Path] = file
+	}
+	return files
+}
+
+func buildSubcommandData(sd *http.ServiceData, e *http.EndpointData) *subcommandData {
+	flags, buildFunction := buildFlags(sd, e)
+
+	sub := &subcommandData{
+		SubcommandData: BuildSubcommandData(sd.Service.Name, e.Method, buildFunction, flags),
+	}
+	if e.MultipartRequestEncoder != nil {
+		sub.MultipartVarName = e.MultipartRequestEncoder.VarName
+		sub.MultipartFuncName = e.MultipartRequestEncoder.FuncName
+	}
+	if e.Method.SkipRequestBodyEncodeDecode {
+		sub.StreamFlag = streamFlag(sd.Service.Name, e.Method.Name)
+		sub.BuildStreamPayload = e.BuildStreamPayload
+	}
+	return sub
+}
+
+// endpointParser returns the file that implements the command line parser that
+// builds the client endpoint and payload necessary to perform a request.
+func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, data []*commandData) *codegen.File {
+	pkg := codegen.SnakeCase(codegen.Goify(svr.Name, true))
+	path := filepath.Join(codegen.Gendir, "http", "cli", pkg, "cli.go")
+	title := fmt.Sprintf("%s HTTP client CLI support package", svr.Name)
+	specs := []*codegen.ImportSpec{
+		{Path: "encoding/json"},
+		{Path: "flag"},
+		{Path: "fmt"},
+		{Path: "net/http"},
+		{Path: "os"},
+		{Path: "strconv"},
+		{Path: "unicode/utf8"},
+		codegen.GoaImport(""),
+		codegen.GoaNamedImport("http", "goahttp"),
+	}
+	for _, sv := range svr.Services {
+		svc := root.Service(sv)
+		sd := http.HTTPServices.Get(svc.Name)
+		if sd == nil {
+			continue
+		}
+		specs = append(specs, &codegen.ImportSpec{
+			Path: genpkg + "/http/" + codegen.SnakeCase(sd.Service.VarName) + "/client",
+			Name: sd.Service.PkgName + "c",
+		})
+	}
+
+	cliData := make([]*CommandData, len(data))
+	for i, cmd := range data {
+		cliData[i] = cmd.CommandData
+	}
+
+	sections := []*codegen.SectionTemplate{
+		codegen.Header(title, "cli", specs),
+		UsageCommands(cliData),
+		UsageExamples(cliData),
+		{
+			Name:   "parse-endpoint",
+			Source: parseEndpointT,
+			Data: struct {
+				FlagsCode string
+				Commands  []*commandData
+			}{
+				FlagsCode(cliData),
+				data,
+			},
+			FuncMap: map[string]interface{}{"streamingCmdExists": streamingCmdExists},
+		},
+	}
+	for _, cmd := range cliData {
+		sections = append(sections, CommandUsage(cmd))
+	}
+	return &codegen.File{Path: path, SectionTemplates: sections}
+}
+
+// payloadBuilders returns the file that contains the payload constructors that
+// use flag values as arguments.
+func payloadBuilders(genpkg string, svc *expr.HTTPServiceExpr, data *CommandData) *codegen.File {
+	sd := http.HTTPServices.Get(svc.Name())
+	path := filepath.Join(codegen.Gendir, "http", codegen.SnakeCase(sd.Service.VarName), "client", "cli.go")
+	title := fmt.Sprintf("%s HTTP client CLI support package", svc.Name())
+	specs := []*codegen.ImportSpec{
+		{Path: "encoding/json"},
+		{Path: "fmt"},
+		{Path: "net/http"},
+		{Path: "os"},
+		{Path: "strconv"},
+		{Path: "unicode/utf8"},
+		codegen.GoaImport(""),
+		codegen.GoaNamedImport("http", "goahttp"),
+		{Path: genpkg + "/" + codegen.SnakeCase(sd.Service.VarName), Name: sd.Service.PkgName},
+	}
+	sections := []*codegen.SectionTemplate{
+		codegen.Header(title, "client", specs),
+	}
+	for _, sub := range data.Subcommands {
+		if sub.BuildFunction != nil {
+			sections = append(sections, PayloadBuilderSection(sub.BuildFunction))
+		}
+	}
+
+	return &codegen.File{Path: path, SectionTemplates: sections}
+}
+
+func buildFlags(svc *http.ServiceData, e *http.EndpointData) ([]*FlagData, *BuildFunctionData) {
+	var (
+		flags         []*FlagData
+		buildFunction *BuildFunctionData
+	)
+
+	svcn := svc.Service.Name
+	en := e.Method.Name
+	if e.Payload != nil {
+		if e.Payload.Request.PayloadInit != nil {
+			args := e.Payload.Request.PayloadInit.ClientArgs
+			args = append(args, e.Payload.Request.PayloadInit.CLIArgs...)
+			flags, buildFunction = makeFlags(e, args, e.Payload.Request.PayloadType)
+		} else if e.Payload.Ref != "" {
+			flags = append(flags, NewFlagData(svcn, en, "p", e.Method.PayloadRef, e.Method.PayloadDesc, true, e.Method.PayloadEx, e.Method.PayloadDefault))
+		}
+	}
+	if e.Method.SkipRequestBodyEncodeDecode {
+		flags = append(flags, streamFlag(svcn, en))
+	}
+
+	return flags, buildFunction
+}
+
+func makeFlags(e *http.EndpointData, args []*http.InitArgData, payload expr.DataType) ([]*FlagData, *BuildFunctionData) {
+	var (
+		fdata     []*FieldData
+		flags     = make([]*FlagData, len(args))
+		params    = make([]string, len(args))
+		pInitArgs = make([]*codegen.InitArgData, len(args))
+		check     bool
+	)
+	for i, arg := range args {
+		pInitArgs[i] = &codegen.InitArgData{
+			Name:         arg.VarName,
+			Pointer:      arg.Pointer,
+			FieldName:    arg.FieldName,
+			FieldPointer: arg.FieldPointer,
+			FieldType:    arg.FieldType,
+			Type:         arg.Type,
+		}
+
+		f := NewFlagData(e.ServiceName, e.Method.Name, arg.VarName, arg.TypeName, arg.Description, arg.Required, arg.Example, arg.DefaultValue)
+		flags[i] = f
+		params[i] = f.FullName
+		if arg.FieldName == "" && arg.VarName != "body" {
+			continue
+		}
+		code, chek := FieldLoadCode(f, arg.VarName, arg.TypeName, arg.Validate, arg.DefaultValue, payload)
+		check = check || chek
+		tn := arg.TypeRef
+		if f.Type == "JSON" {
+			// We need to declare the variable without
+			// a pointer to be able to unmarshal the JSON
+			// using its address.
+			tn = arg.TypeName
+		}
+		fdata = append(fdata, &FieldData{
+			Name:    arg.VarName,
+			VarName: arg.VarName,
+			TypeRef: tn,
+			Init:    code,
+		})
+	}
+
+	pInit := PayloadInitData{
+		Code:                       e.Payload.Request.PayloadInit.ClientCode,
+		ReturnTypeAttribute:        e.Payload.Request.PayloadInit.ReturnTypeAttribute,
+		ReturnTypeAttributePointer: e.Payload.Request.PayloadInit.ReturnIsPrimitivePointer,
+		ReturnIsStruct:             e.Payload.Request.PayloadInit.ReturnIsStruct,
+		ReturnTypeName:             e.Payload.Request.PayloadInit.ReturnTypeName,
+		ReturnTypePkg:              e.Payload.Request.PayloadInit.ReturnTypePkg,
+		Args:                       pInitArgs,
+	}
+
+	return flags, &BuildFunctionData{
+		Name:         "Build" + e.Method.VarName + "Payload",
+		ActualParams: params,
+		FormalParams: params,
+		ServiceName:  e.ServiceName,
+		MethodName:   e.Method.Name,
+		ResultType:   e.Payload.Ref,
+		Fields:       fdata,
+		PayloadInit:  &pInit,
+		CheckErr:     check,
+	}
+}
+
+// streamFlag returns the flag used to specify the upload file for endpoints
+// that use SkipRequestBodyEncodeDecode.
+func streamFlag(svcn, en string) *FlagData {
+	return NewFlagData(svcn, en, "stream", "string", "path to file containing the streamed request body", true, "goa.png", nil)
+}
+
+// streamingCmdExists returns true if at least one command in the list of commands
+// uses stream for sending payload/result.
+func streamingCmdExists(data []*commandData) bool {
+	for _, c := range data {
+		if c.NeedStream {
+			return true
+		}
+	}
+	return false
+}
+
+const parseEndpointT = `// ParseEndpoint returns the endpoint and payload as specified on the command
+// line.
+func ParseEndpoint(
+	scheme, host string,
+	doer goahttp.Doer,
+	enc func(*http.Request) goahttp.Encoder,
+	dec func(*http.Response) goahttp.Decoder,
+	restore bool,
+	{{- if streamingCmdExists .Commands }}
+	dialer goahttp.Dialer,
+		{{- range .Commands }}
+			{{- if .NeedStream }}
+				{{ .VarName }}Configurer *{{ .PkgName }}.ConnConfigurer,
+			{{- end }}
+		{{- end }}
+	{{- end }}
+	{{- range $c := .Commands }}
+	{{- range .Subcommands }}
+		{{- if .MultipartVarName }}
+	{{ .MultipartVarName }} {{ $c.PkgName }}.{{ .MultipartFuncName }},
+		{{- end }}
+	{{- end }}
+	{{- end }}
+) (goa.Endpoint, interface{}, error) {
+	{{ .FlagsCode }}
+    var (
+		data     interface{}
+		endpoint goa.Endpoint
+		err      error
+	)
+	{
+		switch svcn {
+	{{- range .Commands }}
+		case "{{ .Name }}":
+			c := {{ .PkgName }}.NewClient(scheme, host, doer, enc, dec, restore{{ if .NeedStream }}, dialer, {{ .VarName }}Configurer{{ end }})
+			switch epn {
+		{{- $pkgName := .PkgName }}{{ range .Subcommands }}
+			case "{{ .Name }}":
+				endpoint = c.{{ .MethodVarName }}({{ if .MultipartVarName }}{{ .MultipartVarName }}{{ end }})
+			{{- if .BuildFunction }}
+				data, err = {{ $pkgName}}.{{ .BuildFunction.Name }}({{ range .BuildFunction.ActualParams }}*{{ . }}Flag, {{ end }})
+			{{- else if .Conversion }}
+				{{ .Conversion }}
+			{{- else }}
+				data = nil
+			{{- end }}
+			{{- if .StreamFlag }}
+				{{- if .BuildFunction }}
+				if err == nil {
+				{{- end }}
+					data, err = {{ $pkgName }}.{{ .BuildStreamPayload }}({{ if or .BuildFunction .Conversion }}data, {{ end }}*{{ .StreamFlag.FullName }}Flag)
+				{{- if .BuildFunction }}
+				}
+				{{- end }}
+			{{- end }}
+		{{- end }}
+			}
+	{{- end }}
+		}
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return endpoint, data, nil
+}
+`

--- a/design/cli/http.go
+++ b/design/cli/http.go
@@ -52,15 +52,6 @@ func Generate(genpkg string, roots []eval.Root, files []*codegen.File) ([]*codeg
 					*file = *f
 					fmt.Printf("FuseML overriden file: %s\n", file.Path)
 				}
-				// fmt.Printf("FUSEML: file %s\n", file.Path)
-				// for _, template := range file.SectionTemplates {
-				// 	fmt.Printf("FUSEML:     template %s\n", template.Name)
-				// 	fmt.Printf("FUSEML:         source %s\n", template.Source)
-				// 	for fnc, _ := range template.FuncMap {
-				// 		fmt.Printf("FUSEML:         function %s\n", fnc)
-				// 	}
-
-				// }
 			}
 		}
 	}

--- a/design/cli/http.go
+++ b/design/cli/http.go
@@ -197,6 +197,7 @@ func payloadBuilders(genpkg string, svc *expr.HTTPServiceExpr, data *CommandData
 		{Path: "unicode/utf8"},
 		codegen.GoaImport(""),
 		codegen.GoaNamedImport("http", "goahttp"),
+		{Name: "yaml", Path: "github.com/goccy/go-yaml"},
 		{Path: genpkg + "/" + codegen.SnakeCase(sd.Service.VarName), Name: sd.Service.PkgName},
 	}
 	sections := []*codegen.SectionTemplate{
@@ -262,9 +263,9 @@ func makeFlags(e *http.EndpointData, args []*http.InitArgData, payload expr.Data
 		code, chek := FieldLoadCode(f, arg.VarName, arg.TypeName, arg.Validate, arg.DefaultValue, payload)
 		check = check || chek
 		tn := arg.TypeRef
-		if f.Type == "JSON" {
+		if f.Type == "YAML" {
 			// We need to declare the variable without
-			// a pointer to be able to unmarshal the JSON
+			// a pointer to be able to unmarshal the YAML
 			// using its address.
 			tn = arg.TypeName
 		}

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,7 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -245,6 +246,7 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/getkin/kin-openapi v0.53.0 h1:7WzP+MZRRe7YQz2Kc74Ley3dukJmXDvifVbElGmQfoA=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -272,6 +274,7 @@ github.com/go-openapi/analysis v0.19.2/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9sn
 github.com/go-openapi/analysis v0.19.4/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
 github.com/go-openapi/analysis v0.19.5/go.mod h1:hkEAkxagaIvIP7VTn8ygJNkd4kAYON2rCu0v0ObL0AU=
 github.com/go-openapi/analysis v0.19.10/go.mod h1:qmhS3VNFxBlquFJ0RGoDtylO9y4pgTAUNE9AEEMdlJQ=
+github.com/go-openapi/analysis v0.19.16 h1:Ub9e++M8sDwtHD+S587TYi+6ANBG1NRYGZDihqk0SaY=
 github.com/go-openapi/analysis v0.19.16/go.mod h1:GLInF007N83Ad3m8a/CbQ5TPzdnGT7workfHwuVjNVk=
 github.com/go-openapi/errors v0.17.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
 github.com/go-openapi/errors v0.18.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
@@ -280,6 +283,7 @@ github.com/go-openapi/errors v0.19.3/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA
 github.com/go-openapi/errors v0.19.6/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
 github.com/go-openapi/errors v0.19.7/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
 github.com/go-openapi/errors v0.19.8/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
+github.com/go-openapi/errors v0.19.9 h1:9SnKdGhiPZHF3ttwFMiCBEb8jQ4IDdrK+5+a0oTygA4=
 github.com/go-openapi/errors v0.19.9/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
@@ -305,6 +309,7 @@ github.com/go-openapi/loads v0.19.5/go.mod h1:dswLCAdonkRufe/gSUC3gN8nTSaB9uaS2e
 github.com/go-openapi/loads v0.19.6/go.mod h1:brCsvE6j8mnbmGBh103PT/QLHfbyDxA4hsKvYBNEGVc=
 github.com/go-openapi/loads v0.19.7/go.mod h1:brCsvE6j8mnbmGBh103PT/QLHfbyDxA4hsKvYBNEGVc=
 github.com/go-openapi/loads v0.20.0/go.mod h1:2LhKquiE513rN5xC6Aan6lYOSddlL8Mp20AW9kpviM4=
+github.com/go-openapi/loads v0.20.2 h1:z5p5Xf5wujMxS1y8aP+vxwW5qYT2zdJBbXKmQUG3lcc=
 github.com/go-openapi/loads v0.20.2/go.mod h1:hTVUotJ+UonAMMZsvakEgmWKgtulweO9vYP2bQYKA/o=
 github.com/go-openapi/runtime v0.0.0-20180920151709-4f900dc2ade9/go.mod h1:6v9a6LTXWQCdL8k1AO3cvqx5OtZY/Y9wKTgaoP6YRfA=
 github.com/go-openapi/runtime v0.19.0/go.mod h1:OwNfisksmmaZse4+gpV3Ne9AyMOlP1lt4sK4FXt0O64=
@@ -332,6 +337,7 @@ github.com/go-openapi/strfmt v0.19.3/go.mod h1:0yX7dbo8mKIvc3XSKp7MNfxw4JytCfCD6
 github.com/go-openapi/strfmt v0.19.4/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-openapi/strfmt v0.19.5/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-openapi/strfmt v0.19.11/go.mod h1:UukAYgTaQfqJuAFlNxxMWNvMYiwiXtLsF2VwmoFtbtc=
+github.com/go-openapi/strfmt v0.20.0 h1:l2omNtmNbMc39IGptl9BuXBEKcZfS8zjrTsPKTiJiDM=
 github.com/go-openapi/strfmt v0.20.0/go.mod h1:UukAYgTaQfqJuAFlNxxMWNvMYiwiXtLsF2VwmoFtbtc=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
@@ -360,6 +366,7 @@ github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7a
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
@@ -668,6 +675,7 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -914,6 +922,7 @@ go.mongodb.org/mongo-driver v1.3.0/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS
 go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.4.3/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.mongodb.org/mongo-driver v1.4.4/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
+go.mongodb.org/mongo-driver v1.4.6 h1:rh7GdYmDrb8AQSkF8yteAus8qYOgOASWDOv1BWqBXkU=
 go.mongodb.org/mongo-driver v1.4.6/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=


### PR DESCRIPTION
Introduces a goa plugin used to generate CLI code with fuseml customizations. It is based on the original CLI client code taken from goa. The PR also includes customizations:
* switched to YAML as the body format used for the CLI commands
* enabled strict checking for YAML encoder (duplicate keys and unknown keys are signalled as errors now)