### PR TITLE
Codesets: add arguments to 'codeset register' CLI command

### DIFF
--- a/cmd/fuseml_core-cli/main.go
+++ b/cmd/fuseml_core-cli/main.go
@@ -100,8 +100,7 @@ func main() {
 	// (Number and validity of args was already checked when creating payload)
 	if data != nil && flag.Arg(0) == "codeset" && flag.Arg(1) == "register" {
 		rp := payload.(*codeset.RegisterPayload)
-		codeset := rp.Codeset
-		err := gitc.Push(codeset.Project, codeset.Name, rp.Location)
+		err := gitc.Push(rp.Project, rp.Name, rp.Location)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)

--- a/design/codeset.go
+++ b/design/codeset.go
@@ -62,11 +62,25 @@ var _ = Service("codeset", func() {
 		Description("Register a Codeset with the FuseML codeset store.")
 
 		Payload(func() {
-			Field(1, "codeset", Codeset, "Codeset descriptor")
-			Field(2, "location", String, "Path to the code that should be registered as Codeset", func() {
-				Example("mlflow-project-01")
+			Field(1, "name", String, "The name of the Codeset", func() {
+				Example("mlflow-app-01")
+				Pattern(`^[A-Za-z0-9_][A-Za-z0-9-_]*$`)
 			})
-			Required("codeset", "location")
+			Field(2, "project", String, "The project this Codeset belongs to", func() {
+				Example("mlflow-project-01")
+				Pattern(`^[A-Za-z0-9_][A-Za-z0-9-_]*$`)
+			})
+			Field(3, "description", String, "Codeset description", func() {
+				Example("My first MLFlow application with FuseML")
+				Default("")
+			})
+			Field(4, "labels", ArrayOf(String), "Additional Codeset labels that helps with identifying the type", func() {
+				Example([]string{"mlflow", "playground"})
+			})
+			Field(5, "location", String, "Path to the code that should be registered as Codeset", func() {
+				Example("work/ml/mlflow-code")
+			})
+			Required("name", "project", "location")
 		})
 
 		Error("BadRequest", func() {
@@ -77,9 +91,11 @@ var _ = Service("codeset", func() {
 
 		HTTP(func() {
 			POST("/codesets")
-			Param("location", String, "Path to the code that should be registered as Codeset", func() {
-				Example("work/ml/mlflow-code")
-			})
+			Param("name")
+			Param("project")
+			Param("description")
+			Param("labels")
+			Param("location")
 			Response(StatusCreated)
 			Response("BadRequest", StatusBadRequest)
 		})
@@ -137,6 +153,7 @@ var Codeset = Type("Codeset", func() {
 	})
 	Field(3, "description", String, "Codeset description", func() {
 		Example("My first MLFlow application with FuseML")
+		Default("")
 	})
 	Field(4, "labels", ArrayOf(String), "Additional Codeset labels that helps with identifying the type", func() {
 		Example([]string{"mlflow", "playground"})

--- a/pkg/core/codeset_store.go
+++ b/pkg/core/codeset_store.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/fuseml/fuseml-core/gen/codeset"
+	"github.com/fuseml/fuseml-core/pkg/domain"
 )
 
 // GitAdmin is an inteface to git administration clients
 type GitAdmin interface {
-	PrepareRepository(*codeset.Codeset, *string) error
+	PrepareRepository(*domain.Codeset, *string) error
 	CreateRepoWebhook(string, string, *string) error
-	GetRepositories(org, label *string) ([]*codeset.Codeset, error)
-	GetRepository(org, name string) (*codeset.Codeset, error)
+	GetRepositories(org, label *string) ([]*domain.Codeset, error)
+	GetRepository(org, name string) (*domain.Codeset, error)
 }
 
 // GitCodesetStore describes a stucture that accesses codeset store implemented in git
@@ -29,7 +29,7 @@ func NewGitCodesetStore(gitAdmin GitAdmin) *GitCodesetStore {
 }
 
 // Find returns a codeset identified by project and name
-func (cs *GitCodesetStore) Find(ctx context.Context, project, name string) (*codeset.Codeset, error) {
+func (cs *GitCodesetStore) Find(ctx context.Context, project, name string) (*domain.Codeset, error) {
 	result, err := cs.gitAdmin.GetRepository(project, name)
 	if err != nil {
 		return nil, errors.Wrap(err, "Fetching Codeset failed")
@@ -38,7 +38,7 @@ func (cs *GitCodesetStore) Find(ctx context.Context, project, name string) (*cod
 }
 
 // GetAll returns all codesets matching given project and label
-func (cs *GitCodesetStore) GetAll(ctx context.Context, project, label *string) ([]*codeset.Codeset, error) {
+func (cs *GitCodesetStore) GetAll(ctx context.Context, project, label *string) ([]*domain.Codeset, error) {
 	result, err := cs.gitAdmin.GetRepositories(project, label)
 	if err != nil {
 		return nil, errors.Wrap(err, "Fetching Codesets failed")
@@ -47,7 +47,7 @@ func (cs *GitCodesetStore) GetAll(ctx context.Context, project, label *string) (
 }
 
 // CreateWebhook adds a new webhook to a codeset
-func (cs *GitCodesetStore) CreateWebhook(ctx context.Context, c *codeset.Codeset, listenerURL string) error {
+func (cs *GitCodesetStore) CreateWebhook(ctx context.Context, c *domain.Codeset, listenerURL string) error {
 	err := cs.gitAdmin.CreateRepoWebhook(c.Project, c.Name, &listenerURL)
 	if err != nil {
 		return errors.Wrap(err, "Creating webhook failed")
@@ -56,7 +56,7 @@ func (cs *GitCodesetStore) CreateWebhook(ctx context.Context, c *codeset.Codeset
 }
 
 // Add creates new codeset
-func (cs *GitCodesetStore) Add(ctx context.Context, c *codeset.Codeset) (*codeset.Codeset, error) {
+func (cs *GitCodesetStore) Add(ctx context.Context, c *domain.Codeset) (*domain.Codeset, error) {
 	err := cs.gitAdmin.PrepareRepository(c, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "Preparing Repository failed")

--- a/pkg/core/gitea/client_test.go
+++ b/pkg/core/gitea/client_test.go
@@ -1,13 +1,14 @@
 package gitea
 
 import (
-	"code.gitea.io/sdk/gitea"
-	codeset "github.com/fuseml/fuseml-core/gen/codeset"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"testing"
+
+	"code.gitea.io/sdk/gitea"
+	"github.com/fuseml/fuseml-core/pkg/domain"
 )
 
 type TestStore struct {
@@ -73,7 +74,7 @@ func (tc testGiteaClient) AdminCreateUser(gitea.CreateUserOption) (*gitea.User, 
 }
 func (tc testGiteaClient) ListOrgTeams(string, gitea.ListTeamsOptions) ([]*gitea.Team, *gitea.Response, error) {
 	// return default team for any org
-	teams := []*gitea.Team{&gitea.Team{Name: "Owners", ID: 42}}
+	teams := []*gitea.Team{{Name: "Owners", ID: 42}}
 	return teams, nil, nil
 }
 func (tc testGiteaClient) AddTeamMember(id int64, username string) (*gitea.Response, error) {
@@ -126,13 +127,12 @@ var (
 	testListenerURL       = &testListenerStringURL
 )
 
-func getTestCodeset() *codeset.Codeset {
+func getTestCodeset() *domain.Codeset {
 
-	description := "Test description"
-	return &codeset.Codeset{
+	return &domain.Codeset{
 		Project:     project1,
 		Name:        name,
-		Description: &description,
+		Description: "Test description",
 		Labels:      []string{"mlflow", "test"},
 	}
 }

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -18,9 +18,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
 
-	"github.com/fuseml/fuseml-core/gen/codeset"
 	"github.com/fuseml/fuseml-core/gen/workflow"
 	"github.com/fuseml/fuseml-core/pkg/core/tekton/builder"
+	"github.com/fuseml/fuseml-core/pkg/domain"
 )
 
 const (
@@ -63,7 +63,7 @@ func (w *WorkflowBackend) CreateWorkflow(ctx context.Context, logger *log.Logger
 }
 
 // CreateWorkflowRun creates a PipelineRun with its default values for received workflow and codeset
-func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, workflowName string, codeset codeset.Codeset) error {
+func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, workflowName string, codeset domain.Codeset) error {
 	pipeline, err := w.tektonClients.PipelineClient.Get(ctx, workflowName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting tekton pipeline %q: %w", workflowName, err)
@@ -269,7 +269,7 @@ STEPS:
 	return &pb.Pipeline
 }
 
-func generatePipelineRun(p *v1beta1.Pipeline, codeset codeset.Codeset) (*v1beta1.PipelineRun, error) {
+func generatePipelineRun(p *v1beta1.Pipeline, codeset domain.Codeset) (*v1beta1.PipelineRun, error) {
 	codesetVersion := "main"
 	prb := builder.NewPipelineRunBuilder(fmt.Sprintf("%s%s-%s-", pipelineRunPrefix, codeset.Project, codeset.Name))
 
@@ -297,7 +297,7 @@ func generatePipelineRun(p *v1beta1.Pipeline, codeset codeset.Codeset) (*v1beta1
 
 	for _, res := range p.Spec.Resources {
 		if res.Type == "git" {
-			prb.ResourceGit(res.Name, *codeset.URL, codesetVersion)
+			prb.ResourceGit(res.Name, codeset.URL, codesetVersion)
 		}
 	}
 	return &prb.PipelineRun, nil

--- a/pkg/core/tekton/tekton_test.go
+++ b/pkg/core/tekton/tekton_test.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
-	"github.com/fuseml/fuseml-core/gen/codeset"
 	"github.com/fuseml/fuseml-core/gen/workflow"
+	"github.com/fuseml/fuseml-core/pkg/domain"
 )
 
 const (
@@ -90,8 +90,11 @@ func TestCreateWorkflowRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	csURL := "http://gitea.10.160.5.140.nip.io/workspace/mlflow-app-01.git"
-	cs := codeset.Codeset{Name: "mlflow-app-01", Project: "workspace", URL: &csURL}
+	cs := domain.Codeset{
+		Name:    "mlflow-app-01",
+		Project: "workspace",
+		URL:     "http://gitea.10.160.5.140.nip.io/workspace/mlflow-app-01.git",
+	}
 	err = b.CreateWorkflowRun(ctx, w.Name, cs)
 	if err != nil {
 		t.Fatalf("Failed to create workflow run %q: %s", w.Name, err)

--- a/pkg/domain/codeset.go
+++ b/pkg/domain/codeset.go
@@ -2,14 +2,26 @@ package domain
 
 import (
 	"context"
-
-	"github.com/fuseml/fuseml-core/gen/codeset"
 )
+
+// Codeset represents a codeset artifact
+type Codeset struct {
+	// The name of the Codeset
+	Name string
+	// The project this Codeset belongs to
+	Project string
+	// Codeset description
+	Description string
+	// Additional Codeset labels that helps with identifying the type
+	Labels []string
+	// Full URL to the Codeset
+	URL string
+}
 
 // CodesetStore is an inteface to codeset stores
 type CodesetStore interface {
-	Find(ctx context.Context, project, name string) (*codeset.Codeset, error)
-	GetAll(ctx context.Context, project, label *string) ([]*codeset.Codeset, error)
-	Add(ctx context.Context, c *codeset.Codeset) (*codeset.Codeset, error)
-	CreateWebhook(context.Context, *codeset.Codeset, string) error
+	Find(ctx context.Context, project, name string) (*Codeset, error)
+	GetAll(ctx context.Context, project, label *string) ([]*Codeset, error)
+	Add(ctx context.Context, c *Codeset) (*Codeset, error)
+	CreateWebhook(context.Context, *Codeset, string) error
 }

--- a/pkg/svc/codeset.go
+++ b/pkg/svc/codeset.go
@@ -19,20 +19,60 @@ func NewCodesetService(logger *log.Logger, store domain.CodesetStore) codeset.Se
 	return &codesetsrvc{logger, store}
 }
 
+func restToDomain(rp *codeset.RegisterPayload) (res *domain.Codeset, err error) {
+	res = &domain.Codeset{
+		Name:        rp.Name,
+		Project:     rp.Project,
+		Labels:      rp.Labels,
+		Description: rp.Description,
+	}
+
+	return res, nil
+}
+
+func domainToRest(c *domain.Codeset) (res *codeset.Codeset) {
+	res = &codeset.Codeset{
+		Name:        c.Name,
+		Project:     c.Project,
+		Description: c.Description,
+		Labels:      c.Labels,
+		URL:         &c.URL,
+	}
+
+	return
+}
+
 // Retrieve information about codesets registered in FuseML.
 func (s *codesetsrvc) List(ctx context.Context, p *codeset.ListPayload) (res []*codeset.Codeset, err error) {
 	s.logger.Print("codeset.list")
-	return s.store.GetAll(ctx, p.Project, p.Label)
+	items, err := s.store.GetAll(ctx, p.Project, p.Label)
+	res = make([]*codeset.Codeset, 0, len(items))
+	for _, c := range items {
+		res = append(res, domainToRest(c))
+	}
+	return res, err
 }
 
 // Register a codeset with the FuseML codeset codesetStore.
 func (s *codesetsrvc) Register(ctx context.Context, p *codeset.RegisterPayload) (res *codeset.Codeset, err error) {
 	s.logger.Print("codeset.register")
-	return s.store.Add(ctx, p.Codeset)
+	c, err := restToDomain(p)
+	if err != nil {
+		return nil, codeset.MakeBadRequest(err)
+	}
+	c, err = s.store.Add(ctx, c)
+	if err != nil {
+		return nil, codeset.MakeBadRequest(err)
+	}
+	return domainToRest(c), nil
 }
 
 // Retrieve an Codeset from FuseML.
 func (s *codesetsrvc) Get(ctx context.Context, p *codeset.GetPayload) (res *codeset.Codeset, err error) {
 	s.logger.Print("codeset.get")
-	return s.store.Find(ctx, p.Project, p.Name)
+	c, err := s.store.Find(ctx, p.Project, p.Name)
+	if err != nil {
+		return nil, codeset.MakeBadRequest(err)
+	}
+	return domainToRest(c), nil
 }

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log"
 
-	"github.com/fuseml/fuseml-core/gen/codeset"
 	"github.com/fuseml/fuseml-core/gen/workflow"
 	"github.com/fuseml/fuseml-core/pkg/core/config"
 	"github.com/fuseml/fuseml-core/pkg/core/tekton"
@@ -16,7 +15,7 @@ import (
 type WorkflowBackend interface {
 	CreateListener(context.Context, *log.Logger, string, bool) (string, error)
 	CreateWorkflow(context.Context, *log.Logger, *workflow.Workflow) error
-	CreateWorkflowRun(context.Context, string, codeset.Codeset) error
+	CreateWorkflowRun(context.Context, string, domain.Codeset) error
 }
 
 // workflow service example implementation.


### PR DESCRIPTION
Model the codeset attributes that need to be supplied when
registering a codeset as CLI command line arguments.

This change also requires defining a separate domain data type
for a codeset record, which further decouples the REST API
layer from the internal core logic used to manage codesets.