### PR TITLE
Delete resources in case of partial failure on workflow assign

### DIFF
--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/fuseml/fuseml-core/gen/workflow"
 )
@@ -26,7 +27,7 @@ type WorkflowBackend interface {
 	DeleteWorkflow(ctx context.Context, logger *log.Logger, workflowName string) error
 	CreateWorkflowRun(ctx context.Context, logger *log.Logger, workflowName string, codeset *Codeset) error
 	ListWorkflowRuns(ctx context.Context, workflow workflow.Workflow, filter WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
-	CreateWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string, wait bool) (*WorkflowListener, error)
+	CreateWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string, timeout time.Duration) (*WorkflowListener, error)
 	DeleteWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string) error
 	GetWorkflowListener(ctx context.Context, workflowName string) (*WorkflowListener, error)
 }

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -5,12 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/fuseml/fuseml-core/gen/workflow"
 	"github.com/fuseml/fuseml-core/pkg/core/config"
 	"github.com/fuseml/fuseml-core/pkg/core/tekton"
 	"github.com/fuseml/fuseml-core/pkg/domain"
 )
+
+// createWorkflowListenerTimeout is the time (in minutes) that FuseML waits for the workflow listener
+// to be available
+const createWorkflowListenerTimeout = 1
 
 // workflow service example implementation.
 // The example methods log the requests and return zero values.
@@ -103,7 +108,7 @@ func (s *workflowsrvc) Assign(ctx context.Context, w *workflow.AssignPayload) (e
 		return workflow.MakeNotFound(err)
 	}
 
-	wfListener, err := s.backend.CreateWorkflowListener(ctx, s.logger, w.Name, true)
+	wfListener, err := s.backend.CreateWorkflowListener(ctx, s.logger, w.Name, createWorkflowListenerTimeout*time.Minute)
 	if err != nil {
 		s.logger.Print(err)
 		return err


### PR DESCRIPTION
Assigning a workflow to a codeset consists of creating 3 tekton resources
(trigger template, trigger binding and event listener).

In case of a failure during the creation, delete any previously created resource.