### PR TITLE
Fix some golint warnings

### DIFF
--- a/pkg/core/gitea/client_test.go
+++ b/pkg/core/gitea/client_test.go
@@ -42,7 +42,7 @@ func testLogger() *log.Logger {
 	return logger
 }
 
-func NewTestGiteaAdminClient(testStore *TestStore) *giteaAdminClient {
+func newTestGiteaAdminClient(testStore *TestStore) *giteaAdminClient {
 	return &giteaAdminClient{
 		giteaClient: &testGiteaClient{testStore},
 		logger:      testLogger(),
@@ -151,7 +151,7 @@ func assertError(t testing.TB, got error, want string) {
 func TestPrepareRepository(t *testing.T) {
 
 	testStore := NewTestStore()
-	testGiteaAdminClient := NewTestGiteaAdminClient(testStore)
+	testGiteaAdminClient := newTestGiteaAdminClient(testStore)
 	code := getTestCodeset()
 
 	// checking initial state of owners team members
@@ -185,7 +185,7 @@ func TestPrepareRepository(t *testing.T) {
 
 func TestGetRepository(t *testing.T) {
 
-	testGiteaAdminClient := NewTestGiteaAdminClient(NewTestStore())
+	testGiteaAdminClient := newTestGiteaAdminClient(NewTestStore())
 
 	// Reading repo that was not added should throw error
 	_, err := testGiteaAdminClient.GetRepository(project1, name)
@@ -207,7 +207,7 @@ func TestGetRepository(t *testing.T) {
 
 func TestGetRepositories(t *testing.T) {
 
-	testGiteaAdminClient := NewTestGiteaAdminClient(NewTestStore())
+	testGiteaAdminClient := newTestGiteaAdminClient(NewTestStore())
 
 	repos, err := testGiteaAdminClient.GetRepositories(&project1, nil)
 	if len(repos) > 0 {

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -189,10 +189,7 @@ func generatePipeline(w workflow.Workflow, namespace string) *v1beta1.Pipeline {
 	pb := builder.NewPipelineBuilder(w.Name, namespace)
 	pb.Meta(builder.Label("fuseml/generated-from", w.Name))
 	pb.Description(*w.Description)
-	globalEnvVars = []EnvVar{
-		EnvVar{"WORKFLOW_NAMESPACE", namespace},
-		EnvVar{"WORKFLOW_NAME", w.Name},
-	}
+	globalEnvVars = []EnvVar{{"WORKFLOW_NAMESPACE", namespace}, {"WORKFLOW_NAME", w.Name}}
 
 	// process the FuseML workflow inputs
 	for _, input := range w.Inputs {


### PR DESCRIPTION
* client_test.go: exported func NewTestGiteaAdminClient returns unexported
type *gitea.giteaAdminClient, which can be annoying to use
* tekton.go: redundant type from array, slice, or map composite literal