### PR TITLE
Refactor workflow store interface

### DIFF
--- a/pkg/core/workflow_store.go
+++ b/pkg/core/workflow_store.go
@@ -5,17 +5,22 @@ import (
 	"time"
 
 	"github.com/fuseml/fuseml-core/gen/workflow"
+	"github.com/fuseml/fuseml-core/pkg/domain"
 )
 
 // WorkflowStore describes in memory store for workflows
 type WorkflowStore struct {
-	items map[string]*workflow.Workflow
+	items        map[string]*workflow.Workflow
+	backend      domain.WorkflowBackend
+	codesetStore domain.CodesetStore
 }
 
 // NewWorkflowStore returns an in-memory workflow store instance
-func NewWorkflowStore() *WorkflowStore {
+func NewWorkflowStore(backend domain.WorkflowBackend, cs domain.CodesetStore) *WorkflowStore {
 	return &WorkflowStore{
-		items: make(map[string]*workflow.Workflow),
+		items:        make(map[string]*workflow.Workflow),
+		backend:      backend,
+		codesetStore: cs,
 	}
 }
 
@@ -26,7 +31,7 @@ func (ws *WorkflowStore) Find(ctx context.Context, name string) *workflow.Workfl
 
 // GetAll returns all workflows that matches a given name.
 func (ws *WorkflowStore) GetAll(ctx context.Context, name string) (result []*workflow.Workflow) {
-	result = make([]*workflow.Workflow, 0, len(ws.items))
+	result = make([]*workflow.Workflow, 0)
 	for _, w := range ws.items {
 		if name == "all" || w.Name == name {
 			result = append(result, w)
@@ -37,8 +42,46 @@ func (ws *WorkflowStore) GetAll(ctx context.Context, name string) (result []*wor
 
 // Add adds a new workflow, based on the Workflow structure provided as argument
 func (ws *WorkflowStore) Add(ctx context.Context, w *workflow.Workflow) (*workflow.Workflow, error) {
+	err := ws.backend.CreateWorkflow(ctx, w)
+	if err != nil {
+		return nil, err
+	}
+
 	workflowCreated := time.Now().Format(time.RFC3339)
 	w.Created = &workflowCreated
 	ws.items[w.Name] = w
 	return w, nil
+}
+
+// AssignCodeset assigns a codeset to a workflow
+func (ws *WorkflowStore) AssignCodeset(ctx context.Context, w *workflow.Workflow, c *domain.Codeset) error {
+
+	url, err := ws.backend.CreateListener(ctx, w.Name, true)
+	if err != nil {
+		return err
+	}
+
+	err = ws.codesetStore.CreateWebhook(ctx, c, url)
+	if err != nil {
+		// FIXME: delete the listener
+		return err
+	}
+
+	err = ws.backend.CreateWorkflowRun(ctx, w.Name, c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetAllRuns lists all the runs of a workflow meeting the filter criteria
+func (ws *WorkflowStore) GetAllRuns(ctx context.Context, w *workflow.Workflow, filters domain.WorkflowRunFilter) (res []*workflow.WorkflowRun, err error) {
+
+	res, err = ws.backend.ListWorkflowRuns(ctx, w, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	return
 }

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"context"
-	"log"
 
 	"github.com/fuseml/fuseml-core/gen/workflow"
 )
@@ -11,15 +10,17 @@ import (
 type WorkflowStore interface {
 	Find(ctx context.Context, name string) *workflow.Workflow
 	GetAll(ctx context.Context, name string) (result []*workflow.Workflow)
-	Add(ctx context.Context, r *workflow.Workflow) (*workflow.Workflow, error)
+	Add(ctx context.Context, w *workflow.Workflow) (*workflow.Workflow, error)
+	AssignCodeset(ctx context.Context, w *workflow.Workflow, c *Codeset) error
+	GetAllRuns(ctx context.Context, w *workflow.Workflow, filters WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
 }
 
 // WorkflowBackend is the interface for the FuseML workflows
 type WorkflowBackend interface {
-	CreateListener(context.Context, *log.Logger, string, bool) (string, error)
-	CreateWorkflow(context.Context, *log.Logger, *workflow.Workflow) error
-	CreateWorkflowRun(context.Context, string, Codeset) error
-	ListWorkflowRuns(context.Context, workflow.Workflow, WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
+	CreateListener(context.Context, string, bool) (string, error)
+	CreateWorkflow(context.Context, *workflow.Workflow) error
+	CreateWorkflowRun(context.Context, string, *Codeset) error
+	ListWorkflowRuns(context.Context, *workflow.Workflow, WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
 }
 
 // WorkflowRunFilter defines the available filter when listing workflow runs


### PR DESCRIPTION
* hide Tekton backend use from workflow store consumers. Only the workflow
store interacts with the Tekton backend
* add the codeset store as a member of the workflow store, and
move intra-domain interactions between these components to the
workflow store. Close interactions between core components should be
implemented within the components themselves rather than implemented
outside the core (i.e. not in REST services)
* the workflow store acts as a front-end for all workflow related
operations, not just workflow storage
* fixed some "pass by value" occurrences of larger structs (not
recommended for performance reasons)