### PR TITLE
Implements workflow unassign and delete

### DIFF
--- a/design/workflow.go
+++ b/design/workflow.go
@@ -107,21 +107,16 @@ var _ = Service("workflow", func() {
 		Error("BadRequest", func() {
 			Description("If name is not given, should return 400 Bad Request.")
 		})
-		Error("NotFound", func() {
-			Description("If there is no workflow with the given name, should return 404 Not Found.")
-		})
 
 		HTTP(func() {
 			DELETE("/workflows/{name}")
 			Response(StatusNoContent)
 			Response("BadRequest", StatusBadRequest)
-			Response("NotFound", StatusNotFound)
 		})
 
 		GRPC(func() {
 			Response(CodeOK)
 			Response("BadRequest", CodeInvalidArgument)
-			Response("NotFound", CodeNotFound)
 		})
 	})
 
@@ -231,7 +226,7 @@ var _ = Service("workflow", func() {
 		Description("List Workflow runs.")
 
 		Payload(func() {
-			Field(1, "workflowName", String, "Name of the Workflow to list runs from", func() {
+			Field(1, "name", String, "Name of the Workflow to list runs from", func() {
 				Example("mlflow-sklearn-e2e")
 			})
 			Field(2, "codesetName", String, "Name of the codeset to list runs from", func() {
@@ -251,11 +246,11 @@ var _ = Service("workflow", func() {
 			Description("If there is no workflow with the given name, should return 404 Not Found.")
 		})
 
-		Result(ArrayOf(WorkflowRun), "Return all runs for a workflow.")
+		Result(ArrayOf(WorkflowRun), "Return all runs of a workflow.")
 
 		HTTP(func() {
 			GET("/workflows/runs")
-			Param("workflowName")
+			Param("name")
 			Param("codesetName")
 			Param("codesetProject")
 			Param("status")

--- a/design/workflow.go
+++ b/design/workflow.go
@@ -8,7 +8,7 @@ var _ = Service("workflow", func() {
 	Description("The workflow service performs operations on workflows.")
 
 	Method("list", func() {
-		Description("List workflows registered in FuseML.")
+		Description("List Workflows.")
 		Payload(func() {
 			Field(1, "name", String, "List workflows with the specified name", func() {
 				Example("workflowA")
@@ -37,7 +37,7 @@ var _ = Service("workflow", func() {
 	})
 
 	Method("register", func() {
-		Description("Register a workflow within the FuseML workflow store.")
+		Description("Register a new Workflow.")
 		Payload(Workflow, "Workflow descriptor")
 		Error("BadRequest", func() {
 			Description("If the workflow does not have the required fields, should return 400 Bad Request.")
@@ -62,7 +62,7 @@ var _ = Service("workflow", func() {
 	})
 
 	Method("get", func() {
-		Description("Retrieve Workflow(s) from FuseML.")
+		Description("Get a Workflow.")
 
 		Payload(func() {
 			Field(1, "name", String, "Workflow name", func() {
@@ -94,8 +94,39 @@ var _ = Service("workflow", func() {
 		})
 	})
 
+	Method("delete", func() {
+		Description("Delete a Workflow and its assignments.")
+
+		Payload(func() {
+			Field(1, "name", String, "Workflow name", func() {
+				Example("mlflow-sklearn-e2e")
+			})
+			Required("name")
+		})
+
+		Error("BadRequest", func() {
+			Description("If name is not given, should return 400 Bad Request.")
+		})
+		Error("NotFound", func() {
+			Description("If there is no workflow with the given name, should return 404 Not Found.")
+		})
+
+		HTTP(func() {
+			DELETE("/workflows/{name}")
+			Response(StatusNoContent)
+			Response("BadRequest", StatusBadRequest)
+			Response("NotFound", StatusNotFound)
+		})
+
+		GRPC(func() {
+			Response(CodeOK)
+			Response("BadRequest", CodeInvalidArgument)
+			Response("NotFound", CodeNotFound)
+		})
+	})
+
 	Method("assign", func() {
-		Description("Assigins a Workflow to a Codeset")
+		Description("Assign a Workflow to a Codeset.")
 
 		Payload(func() {
 			Field(1, "name", String, "Name of the Workflow to be associated with the codeset", func() {
@@ -118,7 +149,7 @@ var _ = Service("workflow", func() {
 		})
 
 		HTTP(func() {
-			POST("/workflows/assign")
+			POST("/workflows/assignments")
 			Param("name")
 			Param("codesetName")
 			Param("codesetProject")
@@ -134,8 +165,70 @@ var _ = Service("workflow", func() {
 		})
 	})
 
+	Method("unassign", func() {
+		Description("Unassign a Workflow from a Codeset.")
+
+		Payload(func() {
+			Field(1, "name", String, "Name of the Workflow to be unassigned", func() {
+				Example("mlflow-sklearn-e2e")
+			})
+			Field(2, "codesetProject", String, "Project that hosts the codeset to be unassigned to the workflow", func() {
+				Example("workspace")
+			})
+			Field(3, "codesetName", String, "Codeset to be unassigned to the workflow", func() {
+				Example("mlflow-project-001")
+			})
+			Required("name", "codesetProject", "codesetName")
+		})
+
+		Error("BadRequest", func() {
+			Description("If no workflowName or codeset name/project is given, should return 400 Bad Request.")
+		})
+		Error("NotFound", func() {
+			Description("If there is no workflow assignment with the given workflow and codeset, should return 404 Not Found.")
+		})
+
+		HTTP(func() {
+			DELETE("/workflows/assignments/{name}")
+			Param("name")
+			Param("codesetName")
+			Param("codesetProject")
+			Response(StatusNoContent)
+			Response("BadRequest", StatusBadRequest)
+			Response("NotFound", StatusNotFound)
+		})
+
+		GRPC(func() {
+			Response(CodeOK)
+			Response("BadRequest", CodeInvalidArgument)
+			Response("NotFound", CodeNotFound)
+		})
+	})
+
+	Method("listAssignments", func() {
+		Description("List Workflow assignments.")
+
+		Payload(func() {
+			Field(1, "name", String, "Name of the workflow to list assignments", func() {
+				Example("mlflow-sklearn-e2e")
+			})
+		})
+
+		Result(ArrayOf(WorkflowAssignment), "Return a list of workflow assignments.")
+
+		HTTP(func() {
+			GET("/workflows/assignments")
+			Param("name")
+			Response(StatusOK)
+		})
+
+		GRPC(func() {
+			Response(CodeOK)
+		})
+	})
+
 	Method("listRuns", func() {
-		Description("List workflow runs")
+		Description("List Workflow runs.")
 
 		Payload(func() {
 			Field(1, "workflowName", String, "Name of the Workflow to list runs from", func() {
@@ -175,28 +268,6 @@ var _ = Service("workflow", func() {
 			Response("NotFound", CodeNotFound)
 		})
 
-	})
-
-	Method("listAssignments", func() {
-		Description("List workflow assignments to codesets")
-
-		Payload(func() {
-			Field(1, "name", String, "Name of the workflow to list assignments", func() {
-				Example("mlflow-sklearn-e2e")
-			})
-		})
-
-		Result(ArrayOf(WorkflowAssignment), "Return a list of workflow assignments.")
-
-		HTTP(func() {
-			GET("/workflows/assignments")
-			Param("name")
-			Response(StatusOK)
-		})
-
-		GRPC(func() {
-			Response(CodeOK)
-		})
 	})
 })
 

--- a/pkg/cli/git/git.go
+++ b/pkg/cli/git/git.go
@@ -55,6 +55,7 @@ func Push(org, name, location, gitURL string, uname, pass *string, debug bool) e
 	// TODO: use some real API instead...
 	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf(`
 cd "%s"
+rm -rf .git
 git init
 git config user.name "Fuseml"
 git config user.email cli@fuseml

--- a/pkg/core/codeset_store.go
+++ b/pkg/core/codeset_store.go
@@ -11,7 +11,8 @@ import (
 // GitAdmin is an inteface to git administration clients
 type GitAdmin interface {
 	PrepareRepository(*domain.Codeset, *string) (*string, *string, error)
-	CreateRepoWebhook(string, string, *string) error
+	CreateRepoWebhook(string, string, *string) (*int64, error)
+	DeleteRepoWebhook(string, string, *int64) error
 	GetRepositories(org, label *string) ([]*domain.Codeset, error)
 	GetRepository(org, name string) (*domain.Codeset, error)
 	DeleteRepository(org, name string) error
@@ -58,10 +59,19 @@ func (cs *GitCodesetStore) GetAll(ctx context.Context, project, label *string) (
 }
 
 // CreateWebhook adds a new webhook to a codeset
-func (cs *GitCodesetStore) CreateWebhook(ctx context.Context, c *domain.Codeset, listenerURL string) error {
-	err := cs.gitAdmin.CreateRepoWebhook(c.Project, c.Name, &listenerURL)
+func (cs *GitCodesetStore) CreateWebhook(ctx context.Context, c *domain.Codeset, listenerURL string) (*int64, error) {
+	hookID, err := cs.gitAdmin.CreateRepoWebhook(c.Project, c.Name, &listenerURL)
 	if err != nil {
-		return errors.Wrap(err, "Creating webhook failed")
+		return nil, errors.Wrap(err, "Creating webhook failed")
+	}
+	return hookID, nil
+}
+
+// DeleteWebhook deletes a webhook from a codeset
+func (cs *GitCodesetStore) DeleteWebhook(ctx context.Context, c *domain.Codeset, hookID *int64) error {
+	err := cs.gitAdmin.DeleteRepoWebhook(c.Project, c.Name, hookID)
+	if err != nil {
+		return errors.Wrap(err, "Deleting webhook failed")
 	}
 	return nil
 }

--- a/pkg/core/gitea/client_test.go
+++ b/pkg/core/gitea/client_test.go
@@ -102,7 +102,10 @@ func (tc testGiteaClient) ListOrgRepos(org string, opt gitea.ListOrgReposOptions
 }
 
 func (tc testGiteaClient) CreateRepoHook(string, string, gitea.CreateHookOption) (*gitea.Hook, *gitea.Response, error) {
-	return nil, nil, nil
+	return &gitea.Hook{ID: int64(1)}, nil, nil
+}
+func (tc testGiteaClient) DeleteRepoHook(string, string, int64) (*gitea.Response, error) {
+	return &gitea.Response{Response: &httpResp200}, nil
 }
 func (tc testGiteaClient) ListRepoTopics(org, repo string, opt gitea.ListRepoTopicsOptions) ([]string, *gitea.Response, error) {
 	return nil, nil, nil
@@ -233,7 +236,7 @@ func TestDeleteRepository(t *testing.T) {
 		t.Errorf("Error deleting repository")
 	}
 
-	c, err := testGiteaAdminClient.GetRepository(project1, name)
+	c, _ := testGiteaAdminClient.GetRepository(project1, name)
 	if c != nil {
 		t.Errorf("Repository still present after deleting")
 	}

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -77,8 +77,21 @@ func (w *WorkflowBackend) CreateWorkflow(ctx context.Context, logger *log.Logger
 	return nil
 }
 
-// CreateWorkflowRun creates a PipelineRun with its default values for received workflow and codeset
-func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, workflowName string, codeset *domain.Codeset) error {
+// DeleteWorkflow deletes a tekton pipeline with the specified name
+func (w *WorkflowBackend) DeleteWorkflow(ctx context.Context, logger *log.Logger, name string) error {
+	logger.Printf("Deleting tekton pipeline: %s...", name)
+	err := w.tektonClients.PipelineClient.Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return fmt.Errorf("error deleting tekton pipeline %q: %w", name, err)
+		}
+		logger.Printf("Tekton pipeline %q not found, skipping delete...", name)
+	}
+	return nil
+}
+
+// CreateWorkflowRun creates a PipelineRun with its default values for the specified workflow and codeset
+func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, logger *log.Logger, workflowName string, codeset *domain.Codeset) error {
 	pipeline, err := w.tektonClients.PipelineClient.Get(ctx, workflowName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting tekton pipeline %q: %w", workflowName, err)
@@ -89,6 +102,7 @@ func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, workflowName st
 		return fmt.Errorf("error generating tekton pipeline run for workflow %q: %w", workflowName, err)
 	}
 
+	logger.Printf("Creating tekton pipeline run for workflow: %s...", workflowName)
 	_, err = w.tektonClients.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("error creating tekton pipeline run %q: %w", pipelineRun.Name, err)
@@ -120,7 +134,6 @@ func (w *WorkflowBackend) ListWorkflowRuns(ctx context.Context, wf workflow.Work
 			workflowRuns = append(workflowRuns, w.toWorkflowRun(wf, run))
 		}
 	}
-
 	return workflowRuns, nil
 }
 

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -188,8 +188,39 @@ func (w *WorkflowBackend) CreateWorkflowListener(ctx context.Context, logger *lo
 		DashboardURL: fmt.Sprintf("%s/#/namespaces/%s/eventlisteners/%s", w.dashboardURL, w.namespace, el.Name)}, nil
 }
 
+// DeleteWorkflowListener deletes all tekton resources associated to the specified listener name
+func (w *WorkflowBackend) DeleteWorkflowListener(ctx context.Context, logger *log.Logger, name string) error {
+	logger.Printf("Deleting tekton event listener: %s...", name)
+	err := w.tektonClients.EventListenerClient.Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return fmt.Errorf("error deleting tekton event listener %q: %w", name, err)
+		}
+		logger.Printf("Tekton event listener %q not found, skipping delete...", name)
+	}
+
+	logger.Printf("Deleting tekton trigger binding: %s...", name)
+	err = w.tektonClients.TriggerBindingClient.Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return fmt.Errorf("error deleting tekton trigger binding %q: %w", name, err)
+		}
+		logger.Printf("Tekton trigger binding %q not found, skipping delete...", name)
+	}
+
+	logger.Printf("Deleting tekton trigger template: %s...", name)
+	err = w.tektonClients.TriggerTemplateClient.Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return fmt.Errorf("error deleting tekton trigger template %q: %w", name, err)
+		}
+		logger.Printf("Tekton trigger template %q not found, skipping delete...", name)
+	}
+	return nil
+}
+
 // GetWorkflowListener returns the listener for a given workflow
-func (w *WorkflowBackend) GetWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string) (wl *domain.WorkflowListener, err error) {
+func (w *WorkflowBackend) GetWorkflowListener(ctx context.Context, workflowName string) (wl *domain.WorkflowListener, err error) {
 	el, err := w.tektonClients.EventListenerClient.Get(ctx, workflowName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting tekton event listener %q: %w", workflowName, err)

--- a/pkg/core/workflow_store.go
+++ b/pkg/core/workflow_store.go
@@ -37,8 +37,8 @@ func (ws *WorkflowStore) GetWorkflow(ctx context.Context, name string) *workflow
 	return nil
 }
 
-// GetAllWorkflows returns all workflows or the one that matches a given name.
-func (ws *WorkflowStore) GetAllWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow) {
+// GetWorkflows returns all workflows or the one that matches a given name.
+func (ws *WorkflowStore) GetWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow) {
 	result = make([]*workflow.Workflow, 0, len(ws.items))
 	if name != nil {
 		result = append(result, ws.items[*name].workflow)
@@ -60,6 +60,19 @@ func (ws *WorkflowStore) AddWorkflow(ctx context.Context, w *workflow.Workflow) 
 	sw := storableWorkflow{workflow: w}
 	ws.items[w.Name] = &sw
 	return w, nil
+}
+
+// DeleteWorkflow deletes the workflow from the store
+func (ws *WorkflowStore) DeleteWorkflow(ctx context.Context, name string) error {
+	sw, found := ws.items[name]
+	if !found {
+		return nil
+	}
+	if len(sw.assignedCodesets) > 0 {
+		return fmt.Errorf("cannot delete workflow, there are codesets assigned to it")
+	}
+	delete(ws.items, name)
+	return nil
 }
 
 // GetAssignedCodesets returns a list of codesets assigned to the specified workflow
@@ -118,8 +131,8 @@ func (ws *WorkflowStore) GetAssignedCodeset(ctx context.Context, workflowName st
 	return ac
 }
 
-func getAssignedCodeset(slice []*domain.AssignedCodeset, codeset *domain.Codeset) (*domain.AssignedCodeset, int) {
-	for i, ac := range slice {
+func getAssignedCodeset(assignedCodesets []*domain.AssignedCodeset, codeset *domain.Codeset) (*domain.AssignedCodeset, int) {
+	for i, ac := range assignedCodesets {
 		if ac.Codeset.Project == codeset.Project && ac.Codeset.Name == codeset.Name {
 			return ac, i
 		}

--- a/pkg/domain/codeset.go
+++ b/pkg/domain/codeset.go
@@ -23,6 +23,7 @@ type CodesetStore interface {
 	Find(ctx context.Context, project, name string) (*Codeset, error)
 	GetAll(ctx context.Context, project, label *string) ([]*Codeset, error)
 	Add(ctx context.Context, c *Codeset) (*Codeset, *string, *string, error)
-	CreateWebhook(context.Context, *Codeset, string) error
+	CreateWebhook(context.Context, *Codeset, string) (*int64, error)
+	DeleteWebhook(context.Context, *Codeset, *int64) error
 	Delete(ctx context.Context, project, name string) error
 }

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -12,9 +12,9 @@ type WorkflowStore interface {
 	GetWorkflow(ctx context.Context, name string) *workflow.Workflow
 	GetAllWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow)
 	AddWorkflow(ctx context.Context, w *workflow.Workflow) (*workflow.Workflow, error)
-	GetAssignedCodesets(ctx context.Context, workflowName string) []*Codeset
-	GetAssignments(ctx context.Context, workflowName *string) map[string][]*Codeset
-	AddCodesetAssignment(ctx context.Context, workflowName string, codeset *Codeset) []*Codeset
+	GetAssignedCodesets(ctx context.Context, workflowName string) []*AssignedCodeset
+	GetAssignments(ctx context.Context, workflowName *string) map[string][]*AssignedCodeset
+	AddCodesetAssignment(ctx context.Context, workflowName string, assignedCodeset *AssignedCodeset) []*AssignedCodeset
 }
 
 // WorkflowBackend is the interface for the FuseML workflows
@@ -38,4 +38,10 @@ type WorkflowListener struct {
 	Available    bool
 	URL          string
 	DashboardURL string
+}
+
+// AssignedCodeset describes an assigned codeset its webhook ID
+type AssignedCodeset struct {
+	Codeset   *Codeset
+	WebhookID *int64
 }

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -10,8 +10,9 @@ import (
 // WorkflowStore is an inteface to workflow stores
 type WorkflowStore interface {
 	GetWorkflow(ctx context.Context, name string) *workflow.Workflow
-	GetAllWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow)
+	GetWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow)
 	AddWorkflow(ctx context.Context, w *workflow.Workflow) (*workflow.Workflow, error)
+	DeleteWorkflow(ctx context.Context, name string) error
 	GetAssignedCodeset(ctx context.Context, workflowName string, codeset *Codeset) *AssignedCodeset
 	GetAssignedCodesets(ctx context.Context, workflowName string) []*AssignedCodeset
 	GetAssignments(ctx context.Context, workflowName *string) map[string][]*AssignedCodeset
@@ -22,7 +23,8 @@ type WorkflowStore interface {
 // WorkflowBackend is the interface for the FuseML workflows
 type WorkflowBackend interface {
 	CreateWorkflow(ctx context.Context, logger *log.Logger, workflow *workflow.Workflow) error
-	CreateWorkflowRun(ctx context.Context, workflowName string, codeset *Codeset) error
+	DeleteWorkflow(ctx context.Context, logger *log.Logger, workflowName string) error
+	CreateWorkflowRun(ctx context.Context, logger *log.Logger, workflowName string, codeset *Codeset) error
 	ListWorkflowRuns(ctx context.Context, workflow workflow.Workflow, filter WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
 	CreateWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string, wait bool) (*WorkflowListener, error)
 	DeleteWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string) error
@@ -43,7 +45,7 @@ type WorkflowListener struct {
 	DashboardURL string
 }
 
-// AssignedCodeset describes an assigned codeset its webhook ID
+// AssignedCodeset describes a assigned codeset its webhook ID
 type AssignedCodeset struct {
 	Codeset   *Codeset
 	WebhookID *int64

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -12,18 +12,21 @@ type WorkflowStore interface {
 	GetWorkflow(ctx context.Context, name string) *workflow.Workflow
 	GetAllWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow)
 	AddWorkflow(ctx context.Context, w *workflow.Workflow) (*workflow.Workflow, error)
+	GetAssignedCodeset(ctx context.Context, workflowName string, codeset *Codeset) *AssignedCodeset
 	GetAssignedCodesets(ctx context.Context, workflowName string) []*AssignedCodeset
 	GetAssignments(ctx context.Context, workflowName *string) map[string][]*AssignedCodeset
 	AddCodesetAssignment(ctx context.Context, workflowName string, assignedCodeset *AssignedCodeset) []*AssignedCodeset
+	DeleteCodesetAssignment(ctx context.Context, workflowName string, codeset *Codeset) []*AssignedCodeset
 }
 
 // WorkflowBackend is the interface for the FuseML workflows
 type WorkflowBackend interface {
-	CreateWorkflow(context.Context, *log.Logger, *workflow.Workflow) error
-	CreateWorkflowRun(context.Context, string, *Codeset) error
-	ListWorkflowRuns(context.Context, workflow.Workflow, WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
-	CreateWorkflowListener(context.Context, *log.Logger, string, bool) (*WorkflowListener, error)
-	GetWorkflowListener(context.Context, *log.Logger, string) (*WorkflowListener, error)
+	CreateWorkflow(ctx context.Context, logger *log.Logger, workflow *workflow.Workflow) error
+	CreateWorkflowRun(ctx context.Context, workflowName string, codeset *Codeset) error
+	ListWorkflowRuns(ctx context.Context, workflow workflow.Workflow, filter WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
+	CreateWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string, wait bool) (*WorkflowListener, error)
+	DeleteWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string) error
+	GetWorkflowListener(ctx context.Context, workflowName string) (*WorkflowListener, error)
 }
 
 // WorkflowRunFilter defines the available filter when listing workflow runs

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -81,7 +81,7 @@ func (s *workflowsrvc) Assign(ctx context.Context, w *workflow.AssignPayload) (e
 		return err
 	}
 
-	err = s.codesetStore.CreateWebhook(ctx, codeset, wfListener.URL)
+	_, err = s.codesetStore.CreateWebhook(ctx, codeset, wfListener.URL)
 	if err != nil {
 		s.logger.Print(err)
 		return err


### PR DESCRIPTION
This PR adds support for the workflow unassign and delete operations. Besides the changes to workflows, the following changes were made to codesets:
- Adds a function to delete webhook from codeset and update the create
webhook function to also return the created webhook ID.
- Delete `.git` directory before performing `git init` when registering a codeset. This ensures that git initialises correctly when pushing code that is already versioned by git.

TBD:

- [ ] When deleting a codeset, if it has assignments with workflows, remove the assignment.
