### PR TITLE
Allow setting server URL via environment variable FUSEML_SERVER_URL

### DIFF
--- a/cmd/fuseml_cli/main.go
+++ b/cmd/fuseml_cli/main.go
@@ -34,6 +34,9 @@ func main() {
 	{
 		addr = *addrF
 		if addr == "" {
+			addr, _ = os.LookupEnv("FUSEML_SERVER_URL")
+		}
+		if addr == "" {
 			switch *hostF {
 			case "dev":
 				addr = "http://localhost:8000"


### PR DESCRIPTION
This way user does not have to provide -url option for every client invocation.

Next time will add a support for config file, but this is tiny change that already helps...