### PR TITLE
Add job to build/publish docker image on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,18 @@
-name: Release-pipeline
+name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    tags: [ "v*" ]
+    branches: [ main ]
 
 jobs:
   source-and-binaries:
+    name: Source and binaries
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -32,7 +35,7 @@ jobs:
         run: |
           make release
 
-      - name: Generate Changelog
+      - name: Generate changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,9 +55,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker-iamge:
+    name: Docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Login to GHCR
@@ -80,7 +84,18 @@ jobs:
 
       - name: Set image name and tag
         run: |
-          echo "IMG=ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          case "${GITHUB_REF}" in
+            refs/heads/main)
+              TAG="dev"
+              ;;
+            refs/tags/v*)
+              TAG=${GITHUB_REF/refs\/tags\//}
+              ;;
+            *)
+              TAG=${GITHUB_REF/refs\/*\//}
+              ;;
+          esac
+          echo "IMG=ghcr.io/${GITHUB_REPOSITORY}:${TAG}" >> $GITHUB_ENV
          
       - name: Build image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,33 +6,32 @@ on:
       - "v*"
 
 jobs:
-  release:
+  source-and-binaries:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Fetch Branch
-        id: branch
-        run: |
-          raw=$(git branch -r --contains ${{ github.ref }})
-          branch=${raw##*/}
-          echo "::set-output name=BRANCH_NAME::$branch"
+
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.7'
+          go-version: '^1.16'
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+         version: '3.15.7'
+
       - name: Install dependencies
-        if: steps.branch.outputs.BRANCH_NAME == 'main'
         run: |
           make deps
+
       - name: Build binaries
-        if: steps.branch.outputs.BRANCH_NAME == 'main'
         run: |
           make release
+
       - name: Generate Changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.1.1
         with:
@@ -42,12 +41,51 @@ jobs:
           stripGeneratorNotice: "true"
           issuesWoLabels: "true"
           stripHeaders: "true"
+
       - name: Release fuseml-core
         uses: softprops/action-gh-release@v1
-        if: steps.branch.outputs.BRANCH_NAME == 'main'
         with:
           files: ./bin/*
           body_path: ./CHANGELOG.md
           prerelease: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-iamge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+         version: '3.15.7'
+
+      - name: Install dependencies
+        run: |
+          make deps
+
+      - name: Set image name and tag
+        run: |
+          echo "IMG=ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+         
+      - name: Build image
+        run: |
+          make docker-build
+
+      - name: Push image
+        run: |
+          make docker-push


### PR DESCRIPTION
Add a new job to the release workflow to build and push the fuseml-core
docker image.

The image name and tag is derived from the repository name and the release
tag respectively.

The job also runs for push events on the main branch which will push a docker
image with the `dev` tag.

Fixes: https://github.com/fuseml/fuseml/issues/105