### PR TITLE
When user is created for a project, return name and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Example:
 
     Example:
     ```bash
-    bin/fuseml codeset register --name "test" --project "mlflow-project-01" --location "/tmp/mlflow/mlflow-01"
+    bin/fuseml codeset register --name "test" --project "mlflow-project-01" "/tmp/mlflow/mlflow-01"
     ```
 
-    `--location` argument points to the directory on your machine where your ML application code is located.
+    Last argument points to the directory on your machine where your ML application code is located.
 
     After registering, use
     ```
@@ -197,7 +197,7 @@ Let's look at the example for MLflow model, being trained by MLflow and served w
 
   Register the example MLflow model as a codeset:
   ```bash
-  fuseml codeset register --name "mlflow-test" --project "mlflow-project-01" --location "models/mlflow-wines"
+  fuseml codeset register --name "mlflow-test" --project "mlflow-project-01" "models/mlflow-wines"
   ```
 
 * Update the example to fit your setup

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This repository contains the FuseML APIs definitions and core service. For the g
 
   After successful installation using [fuseml-installer](https://github.com/fuseml/fuseml), `fuseml-core` server is already running in the Kubernetes cluster. However, for developmnent and testing purposes it is possible to run it locally locally by setting the env variables
   
-  `GITEA_URL`, `GITEA_USERNAME`, `GITEA_PASSWORD`
+  `GITEA_URL`, `GITEA_ADMIN_USERNAME`, `GITEA_ADMIN_PASSWORD`
   
   and executing `bin/fuseml_core`.
 
@@ -55,8 +55,8 @@ This repository contains the FuseML APIs definitions and core service. For the g
   If you have used [fuseml-installer](https://github.com/fuseml/fuseml) to set up the environment, there is already default gitea instance installed in your Kubernetes cluster. In such case set the values this way:
   ```bash
   export GITEA_URL=http://$(kubectl get VirtualService -n gitea gitea -o jsonpath="{.spec.hosts[0]}")
-  export GITEA_USERNAME=$(kubectl get Secret -n fuseml-workloads gitea-creds -o jsonpath="{.data.username}" | base64 -d)
-  export GITEA_PASSWORD=$(kubectl get Secret -n fuseml-workloads gitea-creds -o jsonpath="{.data.password}" | base64 -d)
+  export GITEA_ADMIN_USERNAME=$(kubectl get Secret -n fuseml-workloads gitea-creds -o jsonpath="{.data.username}" | base64 -d)
+  export GITEA_ADMIN_PASSWORD=$(kubectl get Secret -n fuseml-workloads gitea-creds -o jsonpath="{.data.password}" | base64 -d)
   ```
   It is possible to use external gitea server instead. Make sure to provide correct environment variables.
   

--- a/design/codeset.go
+++ b/design/codeset.go
@@ -87,7 +87,11 @@ var _ = Service("codeset", func() {
 			Description("If the Codeset does not have the required fields, should return 400 Bad Request.")
 		})
 
-		Result(Codeset)
+		Result(func() {
+			Field(1, "codeset", Codeset, "Registered codeset")
+			Field(2, "username", String, "User for accessing new project")
+			Field(3, "password", String, "Password for new user")
+		})
 
 		HTTP(func() {
 			POST("/codesets")

--- a/pkg/cli/codeset/register.go
+++ b/pkg/cli/codeset/register.go
@@ -70,15 +70,22 @@ func (o *RegisterOptions) run() error {
 		return err
 	}
 
-	codeset := response.(*codeset.Codeset)
+	result := response.(*codeset.RegisterResult)
+	codeset := result.Codeset
 
-	err = gitc.Push(o.Project, o.Name, o.Location, *codeset.URL, o.global.Verbose)
+	err = gitc.Push(o.Project, o.Name, o.Location, *codeset.URL, result.Username, result.Password, o.global.Verbose)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return err
 	}
 
 	fmt.Printf("Codeset %s successfully registered\n", *codeset.URL)
+	if result.Username != nil {
+		fmt.Printf("Username for accessing the project %s\n", *result.Username)
+	}
+	if result.Password != nil {
+		fmt.Printf("Password for accessing the project %s\n", *result.Password)
+	}
 
 	return nil
 }

--- a/pkg/cli/git/git.go
+++ b/pkg/cli/git/git.go
@@ -17,7 +17,8 @@ import (
 )
 
 // Push the code from local dir to remote repo
-// If username or password is not provided, use default values
+// If username or password is not provided, use default values, but password
+// provided from env variable GITEA_PROJECT_PASSWORD has the highest priority.
 func Push(org, name, location, gitURL string, uname, pass *string, debug bool) error {
 	log.Printf("Pushing the code to the git repository...")
 
@@ -43,6 +44,10 @@ func Push(org, name, location, gitURL string, uname, pass *string, debug bool) e
 	}
 	if pass != nil {
 		password = *pass
+	}
+	envPassword, exists := os.LookupEnv("FUSEML_PROJECT_PASSWORD")
+	if exists {
+		password = envPassword
 	}
 
 	u.User = url.UserPassword(username, password)

--- a/pkg/cli/git/git.go
+++ b/pkg/cli/git/git.go
@@ -17,7 +17,8 @@ import (
 )
 
 // Push the code from local dir to remote repo
-func Push(org, name, location, gitURL string, debug bool) error {
+// If username or password is not provided, use default values
+func Push(org, name, location, gitURL string, uname, pass *string, debug bool) error {
 	log.Printf("Pushing the code to the git repository...")
 
 	tmpDir, err := ioutil.TempDir("", "codeset-source")
@@ -34,11 +35,15 @@ func Push(org, name, location, gitURL string, debug bool) error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse git url")
 	}
-	// TODO username+password are created by server action before git push
-	// The values could be returned from some POST if we had some init command, but
-	// for now let's assume the values are fixed
 	username := config.DefaultUserName(org)
 	password := config.DefaultUserPassword
+
+	if uname != nil {
+		username = *uname
+	}
+	if pass != nil {
+		password = *pass
+	}
 
 	u.User = url.UserPassword(username, password)
 

--- a/pkg/core/codeset_store.go
+++ b/pkg/core/codeset_store.go
@@ -10,7 +10,7 @@ import (
 
 // GitAdmin is an inteface to git administration clients
 type GitAdmin interface {
-	PrepareRepository(*domain.Codeset, *string) error
+	PrepareRepository(*domain.Codeset, *string) (*string, *string, error)
 	CreateRepoWebhook(string, string, *string) error
 	GetRepositories(org, label *string) ([]*domain.Codeset, error)
 	GetRepository(org, name string) (*domain.Codeset, error)
@@ -67,11 +67,11 @@ func (cs *GitCodesetStore) CreateWebhook(ctx context.Context, c *domain.Codeset,
 }
 
 // Add creates new codeset
-func (cs *GitCodesetStore) Add(ctx context.Context, c *domain.Codeset) (*domain.Codeset, error) {
-	err := cs.gitAdmin.PrepareRepository(c, nil)
+func (cs *GitCodesetStore) Add(ctx context.Context, c *domain.Codeset) (*domain.Codeset, *string, *string, error) {
+	username, password, err := cs.gitAdmin.PrepareRepository(c, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "Preparing Repository failed")
+		return nil, nil, nil, errors.Wrap(err, "Preparing Repository failed")
 	}
 	// Code itself needs to be pushed from client, here we could do some additional registration
-	return c, nil
+	return c, username, password, nil
 }

--- a/pkg/core/gitea/client.go
+++ b/pkg/core/gitea/client.go
@@ -48,8 +48,8 @@ type giteaAdminClient struct {
 }
 
 var errGITEAURLMissing = "Value for gitea URL (GITEA_URL) was not provided."
-var errGITEAUSERNAMEMissing = "Value for gitea user name (GITEA_USERNAME) was not provided."
-var errGITEAPASSWORDMissing = "Value for gitea user password (GITEA_PASSWORD) was not provided."
+var errGITEAADMINUSERNAMEMissing = "Value for gitea admin user name (GITEA_ADMIN_USERNAME) was not provided."
+var errGITEAADMINPASSWORDMissing = "Value for gitea admin user password (GITEA_ADMIN_PASSWORD) was not provided."
 var errRepoNotFound = "Repository by that name not found"
 var lettersForPassword = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 var generatedPasswordLength = 16
@@ -66,13 +66,13 @@ func NewAdminClient(logger *log.Logger) (AdminClient, error) {
 	if !exists {
 		return nil, errors.New(errGITEAURLMissing)
 	}
-	username, exists := os.LookupEnv("GITEA_USERNAME")
+	username, exists := os.LookupEnv("GITEA_ADMIN_USERNAME")
 	if !exists {
-		return nil, errors.New(errGITEAUSERNAMEMissing)
+		return nil, errors.New(errGITEAADMINUSERNAMEMissing)
 	}
-	password, exists := os.LookupEnv("GITEA_PASSWORD")
+	password, exists := os.LookupEnv("GITEA_ADMIN_PASSWORD")
 	if !exists {
-		return nil, errors.New(errGITEAPASSWORDMissing)
+		return nil, errors.New(errGITEAADMINPASSWORDMissing)
 	}
 
 	client, err := gitea.NewClient(url)

--- a/pkg/core/gitea/client_test.go
+++ b/pkg/core/gitea/client_test.go
@@ -164,7 +164,7 @@ func TestPrepareRepository(t *testing.T) {
 		t.Errorf("Initial number of teams is not empty")
 	}
 
-	err := testGiteaAdminClient.PrepareRepository(code, testListenerURL)
+	_, _, err := testGiteaAdminClient.PrepareRepository(code, testListenerURL)
 	if err != nil {
 		t.Errorf("Error preparing repository: %v", err)
 	}

--- a/pkg/domain/codeset.go
+++ b/pkg/domain/codeset.go
@@ -22,7 +22,7 @@ type Codeset struct {
 type CodesetStore interface {
 	Find(ctx context.Context, project, name string) (*Codeset, error)
 	GetAll(ctx context.Context, project, label *string) ([]*Codeset, error)
-	Add(ctx context.Context, c *Codeset) (*Codeset, error)
+	Add(ctx context.Context, c *Codeset) (*Codeset, *string, *string, error)
 	CreateWebhook(context.Context, *Codeset, string) error
 	Delete(ctx context.Context, project, name string) error
 }

--- a/pkg/svc/codeset.go
+++ b/pkg/svc/codeset.go
@@ -54,17 +54,22 @@ func (s *codesetsrvc) List(ctx context.Context, p *codeset.ListPayload) (res []*
 }
 
 // Register a codeset with the FuseML codeset codesetStore.
-func (s *codesetsrvc) Register(ctx context.Context, p *codeset.RegisterPayload) (res *codeset.Codeset, err error) {
+func (s *codesetsrvc) Register(ctx context.Context, p *codeset.RegisterPayload) (*codeset.RegisterResult, error) {
 	s.logger.Print("codeset.register")
 	c, err := codesetRestToDomain(p)
 	if err != nil {
 		return nil, codeset.MakeBadRequest(err)
 	}
-	c, err = s.store.Add(ctx, c)
+	c, username, password, err := s.store.Add(ctx, c)
 	if err != nil {
 		return nil, codeset.MakeBadRequest(err)
 	}
-	return codesetDomainToRest(c), nil
+	res := codeset.RegisterResult{
+		Codeset:  codesetDomainToRest(c),
+		Username: username,
+		Password: password,
+	}
+	return &res, nil
 }
 
 // Retrieve an Codeset from FuseML.


### PR DESCRIPTION
```
> fuseml codeset register --name test03 --project mlflow-project-02 --location /tmp/mlflow/empty
codeset:
  name: test03
  project: mlflow-project-02
  description: ""
  labels: []
  url: ""
username: fuseml-mlflow-project-02
password: NfHK5a84jjJkwzDk

2021/05/26 16:47:21 Pushing the code to the git repository...
```

TODO

- [x] generate password
- [x] check for env variables (when user changes password manually (e.g. from gitea admin interface), fuseml has now way of knowing when pushing _new repository_ to the _same project_

I changed the names of `GITEA_` env variables: this will require change in fuseml-installer too.