### PR TITLE
CLI: Fixed handling of env variables for global options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/spf13/cobra v1.1.3
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/tektoncd/pipeline v0.23.0
 	github.com/tektoncd/triggers v0.13.0

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -24,19 +24,22 @@ func NewCmdRoot() *cobra.Command {
 		Long:  "FuseML command line client",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// You can bind cobra and viper in a few locations, but PersistencePreRunE on the root command works well
-			return initializeConfig(cmd)
+			if err := initializeConfig(cmd); err != nil {
+				return err
+			}
+			return o.Validate()
 		},
 	}
 
 	pf := cmd.PersistentFlags()
-	pf.StringVarP(&o.URL, "url", "u", common.DefaultFuseMLURL, "URL where the FuseML service is running")
+	pf.StringVarP(&o.URL, "url", "u", "", "(FUSEML_SERVER_URL) URL where the FuseML service is running")
 	viper.BindEnv("url", "FUSEML_SERVER_URL")
 
-	pf.IntVar(&o.Timeout, "timeout", common.DefaultHTTPTimeout, "maximum number of seconds to wait for response")
+	pf.IntVar(&o.Timeout, "timeout", common.DefaultHTTPTimeout, "(FUSEML_HTTP_TIMEOUT) maximum number of seconds to wait for response")
 	viper.BindEnv("timeout", "FUSEML_HTTP_TIMEOUT")
 
-	pf.BoolVarP(&o.Verbose, "verbose", "v", false, "print verbose information, such as HTTP request and response details")
-	viper.BindEnv("verbose")
+	pf.BoolVarP(&o.Verbose, "verbose", "v", false, "(FUSEML_VERBOSE) print verbose information, such as HTTP request and response details")
+	viper.BindEnv("verbose", "FUSEML_VERBOSE")
 
 	cmd.AddCommand(codeset.NewCmdCodeset(o))
 	cmd.AddCommand(runnable.NewCmdRunnable(o))

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -1,13 +1,16 @@
 package cli
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/fuseml/fuseml-core/pkg/cli/codeset"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/fuseml/fuseml-core/pkg/cli/runnable"
 	"github.com/fuseml/fuseml-core/pkg/cli/workflow"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -19,19 +22,20 @@ func NewCmdRoot() *cobra.Command {
 		Use:   os.Args[0] + " [--url HOST | -s HOST] [--timeout SECONDS] [--verbose|-v]",
 		Short: "FuseML CLI",
 		Long:  "FuseML command line client",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// You can bind cobra and viper in a few locations, but PersistencePreRunE on the root command works well
+			return initializeConfig(cmd)
+		},
 	}
 
 	pf := cmd.PersistentFlags()
-	pf.StringVarP(&o.URL, "url", "u", "http://localhost:8000", "URL where the FuseML service is running")
-	viper.BindPFlag("url", pf.Lookup("url"))
+	pf.StringVarP(&o.URL, "url", "u", common.DefaultFuseMLURL, "URL where the FuseML service is running")
 	viper.BindEnv("url", "FUSEML_SERVER_URL")
 
-	pf.IntVar(&o.Timeout, "timeout", 30, "maximum number of seconds to wait for response")
-	viper.BindPFlag("timeout", pf.Lookup("timeout"))
+	pf.IntVar(&o.Timeout, "timeout", common.DefaultHTTPTimeout, "maximum number of seconds to wait for response")
 	viper.BindEnv("timeout", "FUSEML_HTTP_TIMEOUT")
 
 	pf.BoolVarP(&o.Verbose, "verbose", "v", false, "print verbose information, such as HTTP request and response details")
-	viper.BindPFlag("verbose", pf.Lookup("verbose"))
 	viper.BindEnv("verbose")
 
 	cmd.AddCommand(codeset.NewCmdCodeset(o))
@@ -39,6 +43,53 @@ func NewCmdRoot() *cobra.Command {
 	cmd.AddCommand(workflow.NewCmdWorkflow(o))
 
 	return cmd
+}
+
+func initializeConfig(cmd *cobra.Command) error {
+
+	// Set the base name of the config file, without the file extension.
+	viper.SetConfigName(common.ConfigFileName)
+
+	// Set the config format and extension
+	viper.SetConfigType("yaml")
+
+	// Set paths where viper should look for the config file.
+	if dirname, err := os.Getwd(); err == nil {
+		viper.AddConfigPath(filepath.Join(dirname, common.ConfigHomeSubdir))
+	}
+	if dirname, err := os.UserHomeDir(); err == nil {
+		viper.AddConfigPath(filepath.Join(dirname, common.ConfigHomeSubdir))
+	}
+
+	// Attempt to read the config file, gracefully ignoring errors
+	// caused by a config file not being found. Return an error
+	// if we cannot parse the config file.
+	if err := viper.ReadInConfig(); err != nil {
+		// It's okay if there isn't a config file
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return err
+		}
+	}
+
+	// Bind the current command's flags to viper
+	bindFlags(cmd)
+
+	return nil
+}
+
+// Bind each cobra flag to its associated viper configuration (config file and environment variable)
+// This is required because viper doesn't work with cobra flags that are also bound to a variable
+// (e.g. using StringVar to bind a flag to a string variable). See https://github.com/spf13/viper/issues/671.
+func bindFlags(cmd *cobra.Command) {
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		// Apply the viper config value to the flag when the flag is not set and viper has a value
+		if !f.Changed && viper.IsSet(f.Name) {
+			val := viper.Get(f.Name)
+			cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
+		}
+	})
+
 }
 
 // Execute creates the root cobra command, which in turn creates all sub-commands and sets all flags appropriately.

--- a/pkg/cli/common/client.go
+++ b/pkg/cli/common/client.go
@@ -38,7 +38,7 @@ func (c *Clients) InitializeClients(o *GlobalOptions) error {
 	if err != nil || u.Host == "" {
 		// assume the scheme part is missing and default to https
 		u, err = url.ParseRequestURI("https://" + o.URL)
-		if err != nil {
+		if err != nil || u.Host == "" {
 			return fmt.Errorf("invalid URL %#v: %s", o.URL, err)
 		}
 	}

--- a/pkg/cli/common/global.go
+++ b/pkg/cli/common/global.go
@@ -3,6 +3,14 @@ package common
 const (
 	// Version is the CLI version
 	Version = "0.1"
+	// ConfigFileName is the name of the FuseML configuration file (without extension)
+	ConfigFileName = "config"
+	// ConfigHomeSubdir is the subdirectory where the FuseML configuration files is located
+	ConfigHomeSubdir = ".fuseml"
+	// DefaultFuseMLURL is the default URL to use for the FuseML server
+	DefaultFuseMLURL = "http://localhost:8000"
+	// DefaultHTTPTimeout is the default HTTP timeout value
+	DefaultHTTPTimeout = 30
 )
 
 // GlobalOptions contains global CLI configuration parameters

--- a/pkg/cli/common/global.go
+++ b/pkg/cli/common/global.go
@@ -1,5 +1,7 @@
 package common
 
+import "fmt"
+
 const (
 	// Version is the CLI version
 	Version = "0.1"
@@ -7,8 +9,6 @@ const (
 	ConfigFileName = "config"
 	// ConfigHomeSubdir is the subdirectory where the FuseML configuration files is located
 	ConfigHomeSubdir = ".fuseml"
-	// DefaultFuseMLURL is the default URL to use for the FuseML server
-	DefaultFuseMLURL = "http://localhost:8000"
 	// DefaultHTTPTimeout is the default HTTP timeout value
 	DefaultHTTPTimeout = 30
 )
@@ -21,4 +21,14 @@ type GlobalOptions struct {
 	Timeout int
 	// Verbose mode prints out additional information
 	Verbose bool
+}
+
+// Validate validates the global configuration
+func (o *GlobalOptions) Validate() error {
+
+	if o.URL == "" {
+		return fmt.Errorf("the URL to the FuseML server must be provided as an argument, or through the FUSEML_SERVER_URL envrionment variable or in the CLI configuration file")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Due to a known limitation in the viper library [1], binding
cobra flags to a go variable and to a viper environment
variable at the same time is not supported.

This commit implements a workaround [2] that updates the flags
according to information extracted by viper from env variables
and configuration files after the cobra logic has finished loading
the flag variables.

The commit also adds support for using an optional fuseml CLI
configuration file where global configuration parameter values
can be stored. This is a yaml file that can be located either at
`$PWD/.fuseml/config.yaml` or at `$HOME/.fuseml/config.yaml`.

The priority in which configuration options are loaded is:
1. explicit set via command line args
2. environment variable
3. configuration file
4. default flag value

The PR also changes the behavior for the FuseML URL option, which no longer has a default flag value and must be set either manually, as a CLI argument, or as environment variable, or through the configuration file. 

[1] spf13/viper#671
[2] https://carolynvanslyck.com/blog/2020/08/sting-of-the-viper/