### PR TITLE
CLI: Add `text` format and implement `text` output for workflow get 

### DIFF
--- a/pkg/cli/application/delete.go
+++ b/pkg/cli/application/delete.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	applicationc "github.com/fuseml/fuseml-core/gen/http/application/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
 )
 
 // deleteOptions holds the options for 'application delete' sub command
 type deleteOptions struct {
-	common.Clients
+	client.Clients
 	global *common.GlobalOptions
 	Name   string
 }
@@ -30,7 +31,7 @@ func newSubCmdApplicationDelete(gOpt *common.GlobalOptions) *cobra.Command {
 		Short: "Delete an application.",
 		Long:  `Delete an application registered by FuseML`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(gOpt))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/application/get.go
+++ b/pkg/cli/application/get.go
@@ -41,7 +41,7 @@ func newSubCmdApplicationGet(gOpt *common.GlobalOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "application name")
-	o.format.AddSingleValueFormattingFlags(cmd)
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
 	cmd.MarkFlagRequired("name")
 	return cmd
 }

--- a/pkg/cli/application/get.go
+++ b/pkg/cli/application/get.go
@@ -5,13 +5,14 @@ import (
 	"os"
 
 	applicationc "github.com/fuseml/fuseml-core/gen/http/application/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
 )
 
 // GetOptions holds the options for 'application get' sub command
 type getOptions struct {
-	common.Clients
+	client.Clients
 	global *common.GlobalOptions
 	format *common.FormattingOptions
 	Name   string
@@ -33,7 +34,7 @@ func newSubCmdApplicationGet(gOpt *common.GlobalOptions) *cobra.Command {
 		Short: "Get an application.",
 		Long:  `Show details about a FuseML application`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(gOpt))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/application/list.go
+++ b/pkg/cli/application/list.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	applicationc "github.com/fuseml/fuseml-core/gen/http/application/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -12,7 +13,7 @@ import (
 
 // listOptions holds the options for 'application list' sub command
 type listOptions struct {
-	common.Clients
+	client.Clients
 	global   *common.GlobalOptions
 	format   *common.FormattingOptions
 	Type     string
@@ -31,16 +32,16 @@ func newListOptions(o *common.GlobalOptions) (res *listOptions) {
 }
 
 // newSubCmdApplicationList creates and returns the cobra command for the `application list` CLI command
-func newSubCmdApplicationList(c *common.GlobalOptions) *cobra.Command {
+func newSubCmdApplicationList(gOpt *common.GlobalOptions) *cobra.Command {
 
-	o := newListOptions(c)
+	o := newListOptions(gOpt)
 
 	cmd := &cobra.Command{
 		Use:   "list [-t|--type TYPE] [-w|--workflow WORKFLOW]",
 		Short: "List applications.",
 		Long:  `Retrieve information about applications registered in FuseML`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(c))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/client/workflow.go
+++ b/pkg/cli/client/workflow.go
@@ -1,0 +1,135 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"time"
+
+	goahttp "goa.design/goa/v3/http"
+
+	workflowc "github.com/fuseml/fuseml-core/gen/http/workflow/client"
+	"github.com/fuseml/fuseml-core/gen/workflow"
+)
+
+// WorkflowClient holds a client for Workflow
+type WorkflowClient struct {
+	c *workflowc.Client
+}
+
+// NewWorkflowClient initializes a WorkflowClient
+func NewWorkflowClient(scheme string, host string, doer goahttp.Doer, encoder func(*http.Request) goahttp.Encoder,
+	decoder func(*http.Response) goahttp.Decoder, verbose bool) *WorkflowClient {
+	wc := &WorkflowClient{workflowc.NewClient(scheme, host, doer, encoder, decoder, verbose)}
+	return wc
+}
+
+// Assign a Workflow to a Codeset.
+func (wc *WorkflowClient) Assign(name, codesetName, codesetProject string) (err error) {
+	request, err := workflowc.BuildAssignPayload(name, codesetName, codesetProject)
+	if err != nil {
+		return
+	}
+
+	_, err = wc.c.Assign()(context.Background(), request)
+	return
+}
+
+// Create a new Workflow.
+func (wc *WorkflowClient) Create(workflowDef string) (*workflow.Workflow, error) {
+	request, err := workflowc.BuildRegisterPayload(workflowDef)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := wc.c.Register()(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.(*workflow.Workflow), nil
+}
+
+// Get a Workflow.
+func (wc *WorkflowClient) Get(name string) (*workflow.Workflow, error) {
+	request, err := workflowc.BuildGetPayload(name)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := wc.c.Get()(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.(*workflow.Workflow), nil
+}
+
+// List Workflows.
+func (wc *WorkflowClient) List(name string) ([]*workflow.Workflow, error) {
+	request, err := workflowc.BuildListPayload(name)
+	if err != nil {
+		return nil, err
+	}
+
+	wfs, err := wc.c.List()(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	return wfs.([]*workflow.Workflow), nil
+}
+
+// ListAssignments lists Workflow assignments.
+func (wc *WorkflowClient) ListAssignments(name string) ([]*workflow.WorkflowAssignment, error) {
+	request, err := workflowc.BuildListAssignmentsPayload(name)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := wc.c.ListAssignments()(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.([]*workflow.WorkflowAssignment), nil
+}
+
+// ListRuns lists Workflow runs.
+func (wc *WorkflowClient) ListRuns(name, codesetName, codesetProject, status string) ([]*workflow.WorkflowRun, error) {
+	request, err := workflowc.BuildListRunsPayload(name, codesetName, codesetProject, status)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := wc.c.ListRuns()(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	wrs := res.([]*workflow.WorkflowRun)
+	sortWorkflowRunsByStartTime(wrs)
+
+	return wrs, nil
+}
+
+func sortWorkflowRunsByStartTime(wrs []*workflow.WorkflowRun) {
+	sort.Sort(workflowRunsByStartTime(wrs))
+}
+
+type workflowRunsByStartTime []*workflow.WorkflowRun
+
+func (wrs workflowRunsByStartTime) Len() int      { return len(wrs) }
+func (wrs workflowRunsByStartTime) Swap(i, j int) { wrs[i], wrs[j] = wrs[j], wrs[i] }
+func (wrs workflowRunsByStartTime) Less(i, j int) bool {
+	if wrs[j].StartTime == nil {
+		return false
+	}
+	if wrs[i].StartTime == nil {
+		return true
+	}
+	layout := time.RFC3339
+	stj, _ := time.Parse(layout, *wrs[j].StartTime)
+	sti, _ := time.Parse(layout, *wrs[i].StartTime)
+	return stj.Before(sti)
+}

--- a/pkg/cli/codeset/delete.go
+++ b/pkg/cli/codeset/delete.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	codesetc "github.com/fuseml/fuseml-core/gen/http/codeset/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
 )
 
 // DeleteOptions holds the options for 'codeset delete' sub command
 type DeleteOptions struct {
-	common.Clients
+	client.Clients
 	global  *common.GlobalOptions
 	Name    string
 	Project string
@@ -32,7 +33,7 @@ func NewSubCmdCodesetDelete(gOpt *common.GlobalOptions) *cobra.Command {
 		Short: "Delete codesets.",
 		Long:  `Delete a codeset from FuseML`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(gOpt))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/codeset/get.go
+++ b/pkg/cli/codeset/get.go
@@ -44,7 +44,7 @@ func NewSubCmdCodesetGet(gOpt *common.GlobalOptions) *cobra.Command {
 
 	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "codeset name")
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "the project to which the codeset belongs")
-	o.format.AddSingleValueFormattingFlags(cmd)
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
 	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("project")
 	return cmd

--- a/pkg/cli/codeset/get.go
+++ b/pkg/cli/codeset/get.go
@@ -5,13 +5,14 @@ import (
 	"os"
 
 	codesetc "github.com/fuseml/fuseml-core/gen/http/codeset/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
 )
 
 // GetOptions holds the options for 'codeset get' sub command
 type GetOptions struct {
-	common.Clients
+	client.Clients
 	global  *common.GlobalOptions
 	format  *common.FormattingOptions
 	Name    string
@@ -35,7 +36,7 @@ func NewSubCmdCodesetGet(gOpt *common.GlobalOptions) *cobra.Command {
 		Short: "Get codesets.",
 		Long:  `Show details about a FuseML codeset`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(gOpt))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/codeset/list.go
+++ b/pkg/cli/codeset/list.go
@@ -7,6 +7,7 @@ import (
 
 	codeset "github.com/fuseml/fuseml-core/gen/codeset"
 	codesetc "github.com/fuseml/fuseml-core/gen/http/codeset/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -14,7 +15,7 @@ import (
 
 // ListOptions holds the options for 'codeset list' sub command
 type ListOptions struct {
-	common.Clients
+	client.Clients
 	global  *common.GlobalOptions
 	format  *common.FormattingOptions
 	Project string
@@ -42,16 +43,16 @@ func NewListOptions(o *common.GlobalOptions) (res *ListOptions) {
 }
 
 // NewSubCmdCodesetList creates and returns the cobra command for the `codeset list` CLI command
-func NewSubCmdCodesetList(c *common.GlobalOptions) *cobra.Command {
+func NewSubCmdCodesetList(gOpt *common.GlobalOptions) *cobra.Command {
 
-	o := NewListOptions(c)
+	o := NewListOptions(gOpt)
 
 	cmd := &cobra.Command{
 		Use:   "list [-p|--project PROJECT] [-l|--label LABEL]",
 		Short: "List codesets.",
 		Long:  `Retrieve information about Codesets registered in FuseML`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(c))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/codeset/register.go
+++ b/pkg/cli/codeset/register.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fuseml/fuseml-core/gen/codeset"
 	codesetc "github.com/fuseml/fuseml-core/gen/http/codeset/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	gitc "github.com/fuseml/fuseml-core/pkg/cli/git"
 	"github.com/spf13/cobra"
@@ -14,7 +15,7 @@ import (
 
 // RegisterOptions holds the options for 'codeset register' sub command
 type RegisterOptions struct {
-	common.Clients
+	client.Clients
 	global      *common.GlobalOptions
 	Name        string
 	Project     string
@@ -39,7 +40,7 @@ func NewSubCmdCodesetRegister(gOpt *common.GlobalOptions) *cobra.Command {
 		Long:  `Register a codeset with FuseML`,
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Location = cmd.Flags().Arg(0)
-			common.CheckErr(o.InitializeClients(gOpt))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/runnable/get.go
+++ b/pkg/cli/runnable/get.go
@@ -5,13 +5,14 @@ import (
 	"os"
 
 	runnablec "github.com/fuseml/fuseml-core/gen/http/runnable/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
 )
 
 // GetOptions holds the options for 'runnable get' sub command
 type GetOptions struct {
-	common.Clients
+	client.Clients
 	global *common.GlobalOptions
 	format *common.FormattingOptions
 	ID     string
@@ -34,7 +35,7 @@ func NewSubCmdRunnableGet(gOpt *common.GlobalOptions) *cobra.Command {
 		Short: "Get runnables.",
 		Long:  `Show details about a FuseML runnable`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(gOpt))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/runnable/get.go
+++ b/pkg/cli/runnable/get.go
@@ -42,7 +42,7 @@ func NewSubCmdRunnableGet(gOpt *common.GlobalOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.ID, "id", "n", "", "runnable ID")
-	o.format.AddSingleValueFormattingFlags(cmd)
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
 	cmd.MarkFlagRequired("id")
 	return cmd
 }

--- a/pkg/cli/runnable/list.go
+++ b/pkg/cli/runnable/list.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	runnablec "github.com/fuseml/fuseml-core/gen/http/runnable/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -14,7 +15,7 @@ import (
 
 // ListOptions holds the options for 'runnable list' sub command
 type ListOptions struct {
-	common.Clients
+	client.Clients
 	global *common.GlobalOptions
 	format *common.FormattingOptions
 	ID     string
@@ -47,9 +48,9 @@ func NewListOptions(o *common.GlobalOptions) (res *ListOptions) {
 }
 
 // NewSubCmdRunnableList creates and returns the cobra command for the `runnable list` CLI command
-func NewSubCmdRunnableList(c *common.GlobalOptions) *cobra.Command {
+func NewSubCmdRunnableList(gOpt *common.GlobalOptions) *cobra.Command {
 
-	o := NewListOptions(c)
+	o := NewListOptions(gOpt)
 	// local variable used to collect the label arguments and then unpack them
 	var labels []string
 
@@ -59,7 +60,7 @@ func NewSubCmdRunnableList(c *common.GlobalOptions) *cobra.Command {
 		Long:  `Retrieve information about Runnables registered in FuseML`,
 		Run: func(cmd *cobra.Command, args []string) {
 			common.UnpackLabelArgs(labels, o.Labels)
-			common.CheckErr(o.InitializeClients(c))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},

--- a/pkg/cli/runnable/register.go
+++ b/pkg/cli/runnable/register.go
@@ -6,13 +6,14 @@ import (
 
 	runnablec "github.com/fuseml/fuseml-core/gen/http/runnable/client"
 	"github.com/fuseml/fuseml-core/gen/runnable"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
 )
 
 // RegisterOptions holds the options for 'runnable register' sub command
 type RegisterOptions struct {
-	common.Clients
+	client.Clients
 	global       *common.GlobalOptions
 	RunnableDesc string
 }
@@ -32,7 +33,7 @@ func NewSubCmdRunnableRegister(gOpt *common.GlobalOptions) *cobra.Command {
 		Short: "Register runnables.",
 		Long:  `Register a runnable with FuseML`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(gOpt))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(common.LoadFileIntoVar(cmd.Flags().Arg(0), &o.RunnableDesc))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())

--- a/pkg/cli/workflow/get.go
+++ b/pkg/cli/workflow/get.go
@@ -2,12 +2,68 @@ package workflow
 
 import (
 	"os"
+	"strings"
+	"text/tabwriter"
+	"text/template"
 
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/formatted"
 
+	"github.com/fuseml/fuseml-core/gen/workflow"
 	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 )
+
+const getTemplate = `{{decorate "bold" "Name"}}:	{{ .Workflow.Name }}
+{{decorate "bold" "Created"}}:	{{ .Workflow.Created }}
+{{- if ne (deref .Workflow.Description) "" }}
+{{decorate "bold" "Description"}}:	{{ deref .Workflow.Description }}
+{{- end }}
+
+{{decorate "params" ""}}{{decorate "underline bold" "Inputs\n"}}
+{{- $l := len .Workflow.Inputs }}{{ if eq $l 0 }}
+ No inputs
+{{- else }}
+ NAME	TYPE	DESCRIPTION	DEFAULT
+{{- range $input := .Workflow.Inputs }}
+{{- if not $input.Default }}
+ {{decorate "bullet" $input.Name }}	{{ $input.Type }}	{{ formatDesc $input.Description }}	{{ "---" }}
+{{- else }}
+ {{decorate "bullet" $input.Name }}	{{ $input.Type }}	{{ formatDesc $input.Description }}	{{ $input.Default }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{decorate "results" ""}}{{decorate "underline bold" "Outputs\n"}}
+{{- if eq (len .Workflow.Outputs) 0 }}
+ No outputs
+{{- else }}
+ NAME	TYPE	DESCRIPTION
+{{- range $output := .Workflow.Outputs }}
+ {{ decorate "bullet" $output.Name }}	{{ $output.Type }}	{{ formatDesc $output.Description }}
+{{- end }}
+{{- end }}
+
+{{decorate "steps" ""}}{{decorate "underline bold" "Steps\n"}}
+{{- $tl := len .Workflow.Steps }}{{ if eq $tl 0 }}
+ No steps
+{{- else }}
+ NAME	IMAGE
+{{- range $s := .Workflow.Steps }}
+ {{decorate "bullet" $s.Name }}	{{ $s.Image }}
+{{- end }}
+{{- end }}
+
+{{decorate "pipelineruns" ""}}{{decorate "underline bold" "Workflow Runs\n"}}
+{{- $rl := len .WorkflowRuns }}{{ if eq $rl 0 }}
+ No workflow runs
+{{- else }}
+ NAME	STARTED	DURATION	STATUS
+{{- range $wr := .WorkflowRuns }}
+ {{decorate "bullet" $wr.Name }}	{{ formatAge $wr.StartTime }}	{{ formatDuration $wr.StartTime $wr.CompletionTime }}	{{ colorStatus $wr.Status }}
+{{- end }}
+{{- end }}
+`
 
 type getOptions struct {
 	client.Clients
@@ -37,7 +93,7 @@ func newSubCmdGet(gOpt *common.GlobalOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.name, "name", "n", "", "workflow name")
-	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatText)
 	cmd.MarkFlagRequired("name")
 	return cmd
 }
@@ -52,7 +108,42 @@ func (o *getOptions) run() error {
 		return err
 	}
 
-	o.format.FormatValue(os.Stdout, wf)
+	if o.format.Format == common.FormatText {
+		wfRuns, err := o.WorkflowClient.ListRuns(o.name, "", "", "")
+		if err != nil {
+			return err
+		}
+
+		var data = struct {
+			Workflow     *workflow.Workflow
+			WorkflowRuns []*workflow.WorkflowRun
+		}{
+			Workflow:     wf,
+			WorkflowRuns: wfRuns,
+		}
+
+		funcMap := template.FuncMap{
+			"decorate":       formatted.DecorateAttr,
+			"formatDesc":     formatDesc,
+			"formatParam":    formatted.Param,
+			"formatAge":      formatAge,
+			"formatDuration": formatDuration,
+			"colorStatus":    formatted.ColorStatus,
+			"join":           strings.Join,
+			"deref":          func(s *string) string { return *s },
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 5, 3, ' ', tabwriter.TabIndent)
+		t := template.Must(template.New("Describe Pipeline").Funcs(funcMap).Parse(getTemplate))
+		err = t.Execute(w, data)
+		if err != nil {
+			return err
+		}
+
+		w.Flush()
+	} else {
+		o.format.FormatValue(os.Stdout, wf)
+	}
 
 	return nil
 }

--- a/pkg/cli/workflow/get.go
+++ b/pkg/cli/workflow/get.go
@@ -1,17 +1,16 @@
 package workflow
 
 import (
-	"context"
 	"os"
 
 	"github.com/spf13/cobra"
 
-	workflowc "github.com/fuseml/fuseml-core/gen/http/workflow/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 )
 
 type getOptions struct {
-	common.Clients
+	client.Clients
 	global *common.GlobalOptions
 	format *common.FormattingOptions
 	name   string
@@ -30,7 +29,7 @@ func newSubCmdGet(gOpt *common.GlobalOptions) *cobra.Command {
 		Short: "Get a workflow",
 		Long:  `Show detailed information from a workflow`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(gOpt))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},
@@ -48,17 +47,12 @@ func (o *getOptions) validate() error {
 }
 
 func (o *getOptions) run() error {
-	request, err := workflowc.BuildGetPayload(o.name)
+	wf, err := o.WorkflowClient.Get(o.name)
 	if err != nil {
 		return err
 	}
 
-	response, err := o.WorkflowClient.Get()(context.Background(), request)
-	if err != nil {
-		return err
-	}
-
-	o.format.FormatValue(os.Stdout, response)
+	o.format.FormatValue(os.Stdout, wf)
 
 	return nil
 }

--- a/pkg/cli/workflow/get.go
+++ b/pkg/cli/workflow/get.go
@@ -38,7 +38,7 @@ func newSubCmdGet(gOpt *common.GlobalOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.name, "name", "n", "", "workflow name")
-	o.format.AddSingleValueFormattingFlags(cmd)
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
 	cmd.MarkFlagRequired("name")
 	return cmd
 }

--- a/pkg/cli/workflow/list_assignments.go
+++ b/pkg/cli/workflow/list_assignments.go
@@ -1,7 +1,6 @@
 package workflow
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -9,13 +8,13 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 
-	workflowc "github.com/fuseml/fuseml-core/gen/http/workflow/client"
 	"github.com/fuseml/fuseml-core/gen/workflow"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 )
 
 type listAssignmentsOptions struct {
-	common.Clients
+	client.Clients
 	global *common.GlobalOptions
 	format *common.FormattingOptions
 	name   string
@@ -54,14 +53,14 @@ func newListAssignmentsOptions(o *common.GlobalOptions) (res *listAssignmentsOpt
 	return
 }
 
-func newSubCmdListAssignments(c *common.GlobalOptions) *cobra.Command {
-	o := newListAssignmentsOptions(c)
+func newSubCmdListAssignments(gOpt *common.GlobalOptions) *cobra.Command {
+	o := newListAssignmentsOptions(gOpt)
 	cmd := &cobra.Command{
 		Use:   "list-assignments [-n|--name NAME]",
 		Short: "Lists one or more workflow assignments",
 		Long:  `Prints a table of the most important information about workflow assignments. You can filter the list by the workflow name.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			common.CheckErr(o.InitializeClients(c))
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
 			common.CheckErr(o.validate())
 			common.CheckErr(o.run())
 		},
@@ -79,17 +78,12 @@ func (o *listAssignmentsOptions) validate() error {
 }
 
 func (o *listAssignmentsOptions) run() error {
-	request, err := workflowc.BuildListAssignmentsPayload(o.name)
+	al, err := o.WorkflowClient.ListAssignments(o.name)
 	if err != nil {
 		return err
 	}
 
-	response, err := o.WorkflowClient.ListAssignments()(context.Background(), request)
-	if err != nil {
-		return err
-	}
-
-	o.format.FormatValue(os.Stdout, response)
+	o.format.FormatValue(os.Stdout, al)
 
 	return nil
 }

--- a/pkg/cli/workflow/utils.go
+++ b/pkg/cli/workflow/utils.go
@@ -1,0 +1,31 @@
+package workflow
+
+import (
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/cli/pkg/formatted"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func formatDesc(desc string) string {
+	if len(desc) > 60 {
+		return desc[0:59] + "..."
+	}
+	return desc
+}
+
+func formatAge(startTime *string) string {
+	st, _ := time.Parse(time.RFC3339, *startTime)
+	return formatted.Age(&v1.Time{Time: st}, clockwork.NewRealClock())
+}
+
+func formatDuration(startTime, completionTime *string) string {
+	layout := time.RFC3339
+	st, _ := time.Parse(layout, *startTime)
+	ct := time.Time{}
+	if completionTime != nil {
+		ct, _ = time.Parse(layout, *completionTime)
+	}
+	return formatted.Duration(&v1.Time{Time: st}, &v1.Time{Time: ct})
+}


### PR DESCRIPTION
- Add the `text` output format, this format should be used when a command
has its own custom format for the output.
- Moves all the workflow functions that interacts with the API to
a client package under pkg/cli/common.
- Implements a custom format bsed on a template for the workflow get
command. The output format is inspired by the tekton CLI.