### PR TITLE
CLI: Implements workflow unassign/delete and other minor fixes

### DIFF
--- a/design/workflow.go
+++ b/design/workflow.go
@@ -146,8 +146,8 @@ var _ = Service("workflow", func() {
 		HTTP(func() {
 			POST("/workflows/assignments")
 			Param("name")
-			Param("codesetName")
 			Param("codesetProject")
+			Param("codesetName")
 			Response(StatusCreated)
 			Response("BadRequest", StatusBadRequest)
 			Response("NotFound", StatusNotFound)
@@ -186,8 +186,8 @@ var _ = Service("workflow", func() {
 		HTTP(func() {
 			DELETE("/workflows/assignments/{name}")
 			Param("name")
-			Param("codesetName")
 			Param("codesetProject")
+			Param("codesetName")
 			Response(StatusNoContent)
 			Response("BadRequest", StatusBadRequest)
 			Response("NotFound", StatusNotFound)
@@ -229,11 +229,11 @@ var _ = Service("workflow", func() {
 			Field(1, "name", String, "Name of the Workflow to list runs from", func() {
 				Example("mlflow-sklearn-e2e")
 			})
-			Field(2, "codesetName", String, "Name of the codeset to list runs from", func() {
-				Example("mlflow-project-001")
-			})
-			Field(3, "codesetProject", String, "Name of the codeset project to list runs from", func() {
+			Field(2, "codesetProject", String, "Name of the codeset project to list runs from", func() {
 				Example("workspace")
+			})
+			Field(3, "codesetName", String, "Name of the codeset to list runs from", func() {
+				Example("mlflow-project-001")
 			})
 			Field(4, "status", String, "status of the workflow runs to list", func() {
 				Enum("", "Started", "Running", "Cancelled", "Succeeded", "Failed", "Completed", "Timeout")
@@ -251,8 +251,8 @@ var _ = Service("workflow", func() {
 		HTTP(func() {
 			GET("/workflows/runs")
 			Param("name")
-			Param("codesetName")
 			Param("codesetProject")
+			Param("codesetName")
 			Param("status")
 			Response(StatusOK)
 			Response("NotFound", StatusNotFound)

--- a/design/workflow.go
+++ b/design/workflow.go
@@ -14,7 +14,7 @@ var _ = Service("workflow", func() {
 				Example("workflowA")
 			})
 		})
-		Result(ArrayOf(Workflow), "Return all registered workflows matching the query.")
+		Result(ArrayOf(Workflow), "Return all workflows matching the query.")
 
 		Error("NotFound", func() {
 			Description("If the workflow is not found, should return 404 Not Found.")
@@ -36,8 +36,8 @@ var _ = Service("workflow", func() {
 
 	})
 
-	Method("register", func() {
-		Description("Register a new Workflow.")
+	Method("create", func() {
+		Description("Create a new Workflow.")
 		Payload(Workflow, "Workflow descriptor")
 		Error("BadRequest", func() {
 			Description("If the workflow does not have the required fields, should return 400 Bad Request.")

--- a/pkg/cli/client/workflow.go
+++ b/pkg/cli/client/workflow.go
@@ -113,6 +113,17 @@ func (wc *WorkflowClient) ListRuns(name, codesetProject, codesetName, status str
 	return wrs, nil
 }
 
+// Unassign removes an assignment between a workflow and a codeset.
+func (wc *WorkflowClient) Unassign(name, codesetProject, codesetName string) (err error) {
+	request, err := workflowc.BuildUnassignPayload(name, codesetProject, codesetName)
+	if err != nil {
+		return
+	}
+
+	_, err = wc.c.Unassign()(context.Background(), request)
+	return
+}
+
 func sortWorkflowRunsByStartTime(wrs []*workflow.WorkflowRun) {
 	sort.Sort(workflowRunsByStartTime(wrs))
 }

--- a/pkg/cli/client/workflow.go
+++ b/pkg/cli/client/workflow.go
@@ -50,6 +50,17 @@ func (wc *WorkflowClient) Create(workflowDef string) (*workflow.Workflow, error)
 	return response.(*workflow.Workflow), nil
 }
 
+// Delete a Workflow and its assignments.
+func (wc *WorkflowClient) Delete(name string) (err error) {
+	request, err := workflowc.BuildDeletePayload(name)
+	if err != nil {
+		return
+	}
+
+	_, err = wc.c.Delete()(context.Background(), request)
+	return
+}
+
 // Get a Workflow.
 func (wc *WorkflowClient) Get(name string) (*workflow.Workflow, error) {
 	request, err := workflowc.BuildGetPayload(name)

--- a/pkg/cli/client/workflow.go
+++ b/pkg/cli/client/workflow.go
@@ -37,12 +37,12 @@ func (wc *WorkflowClient) Assign(name, codesetName, codesetProject string) (err 
 
 // Create a new Workflow.
 func (wc *WorkflowClient) Create(workflowDef string) (*workflow.Workflow, error) {
-	request, err := workflowc.BuildRegisterPayload(workflowDef)
+	request, err := workflowc.BuildCreatePayload(workflowDef)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := wc.c.Register()(context.Background(), request)
+	response, err := wc.c.Create()(context.Background(), request)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/client/workflow.go
+++ b/pkg/cli/client/workflow.go
@@ -25,8 +25,8 @@ func NewWorkflowClient(scheme string, host string, doer goahttp.Doer, encoder fu
 }
 
 // Assign a Workflow to a Codeset.
-func (wc *WorkflowClient) Assign(name, codesetName, codesetProject string) (err error) {
-	request, err := workflowc.BuildAssignPayload(name, codesetName, codesetProject)
+func (wc *WorkflowClient) Assign(name, codesetProject, codesetName string) (err error) {
+	request, err := workflowc.BuildAssignPayload(name, codesetProject, codesetName)
 	if err != nil {
 		return
 	}
@@ -96,8 +96,8 @@ func (wc *WorkflowClient) ListAssignments(name string) ([]*workflow.WorkflowAssi
 }
 
 // ListRuns lists Workflow runs.
-func (wc *WorkflowClient) ListRuns(name, codesetName, codesetProject, status string) ([]*workflow.WorkflowRun, error) {
-	request, err := workflowc.BuildListRunsPayload(name, codesetName, codesetProject, status)
+func (wc *WorkflowClient) ListRuns(name, codesetProject, codesetName, status string) ([]*workflow.WorkflowRun, error) {
+	request, err := workflowc.BuildListRunsPayload(name, codesetProject, codesetName, status)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/workflow/assign.go
+++ b/pkg/cli/workflow/assign.go
@@ -24,7 +24,7 @@ func newAssignOptions(o *common.GlobalOptions) *assignOptions {
 func newSubCmdAssign(gOpt *common.GlobalOptions) *cobra.Command {
 	o := newAssignOptions(gOpt)
 	cmd := &cobra.Command{
-		Use:   "assign {-n|--name NAME} {-c|--codeset-name CODESET_NAME} {-p|--codeset-project CODESET_PROJECT}",
+		Use:   "assign {-n|--name NAME} {-p|--codeset-project CODESET_PROJECT} {-c|--codeset-name CODESET_NAME} ",
 		Short: "Assigns a workflow to a codeset",
 		Long: `Assigning a workflow to a codeset makes any change pushed to the codeset trigger the workflow(s) assigned to it.
 Upon successfully assignment a workflow run is created using the workflow's default inputs and the assigned codeset.`,
@@ -37,8 +37,8 @@ Upon successfully assignment a workflow run is created using the workflow's defa
 	}
 
 	cmd.Flags().StringVarP(&o.name, "name", "n", "", "name of the workflow to be assigned")
-	cmd.Flags().StringVarP(&o.codesetName, "codeset-name", "c", "", "name of the codeset to assign the workflow to")
 	cmd.Flags().StringVarP(&o.codesetProject, "codeset-project", "p", "", "name of the project to which the codeset belongs")
+	cmd.Flags().StringVarP(&o.codesetName, "codeset-name", "c", "", "name of the codeset to assign the workflow to")
 	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("codeset-name")
 	cmd.MarkFlagRequired("codeset-project")
@@ -51,7 +51,7 @@ func (o *assignOptions) validate() error {
 }
 
 func (o *assignOptions) run() error {
-	err := o.WorkflowClient.Assign(o.name, o.codesetName, o.codesetProject)
+	err := o.WorkflowClient.Assign(o.name, o.codesetProject, o.codesetName)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/workflow/cmd.go
+++ b/pkg/cli/workflow/cmd.go
@@ -21,6 +21,7 @@ func NewCmdWorkflow(c *common.GlobalOptions) *cobra.Command {
 	cmd.AddCommand(newSubCmdListAssignments(c))
 	cmd.AddCommand(newSubCmdListRuns(c))
 	cmd.AddCommand(newSubCmdUnassign(c))
+	cmd.AddCommand(newSubCmdDelete(c))
 
 	return cmd
 }

--- a/pkg/cli/workflow/cmd.go
+++ b/pkg/cli/workflow/cmd.go
@@ -20,6 +20,7 @@ func NewCmdWorkflow(c *common.GlobalOptions) *cobra.Command {
 	cmd.AddCommand(newSubCmdAssign(c))
 	cmd.AddCommand(newSubCmdListAssignments(c))
 	cmd.AddCommand(newSubCmdListRuns(c))
+	cmd.AddCommand(newSubCmdUnassign(c))
 
 	return cmd
 }

--- a/pkg/cli/workflow/delete.go
+++ b/pkg/cli/workflow/delete.go
@@ -1,0 +1,55 @@
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+)
+
+type deleteOptions struct {
+	client.Clients
+	global *common.GlobalOptions
+	name   string
+}
+
+func newDeleteOptions(o *common.GlobalOptions) (res *deleteOptions) {
+	return &deleteOptions{global: o}
+}
+
+func newSubCmdDelete(gOpt *common.GlobalOptions) *cobra.Command {
+	o := newDeleteOptions(gOpt)
+	cmd := &cobra.Command{
+		Use:   "delete [-n|--name NAME]",
+		Short: "Deletes a workflow",
+		Long:  `Delete a workflow and all existing assignments to it.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
+			common.CheckErr(o.validate())
+			common.CheckErr(o.run())
+		},
+		Args: cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().StringVarP(&o.name, "name", "n", "", "name of the workflow to be deleted")
+	cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func (o *deleteOptions) validate() error {
+	return nil
+}
+
+func (o *deleteOptions) run() error {
+	err := o.WorkflowClient.Delete(o.name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Workflow %s successfully deleted\n", o.name)
+
+	return nil
+}

--- a/pkg/cli/workflow/list_runs.go
+++ b/pkg/cli/workflow/list_runs.go
@@ -75,7 +75,7 @@ func newListRunsOptions(o *common.GlobalOptions) (res *listRunsOptions) {
 func newSubCmdListRuns(gOpt *common.GlobalOptions) *cobra.Command {
 	o := newListRunsOptions(gOpt)
 	cmd := &cobra.Command{
-		Use:   "list-runs [-n|--name NAME] [-c|--codeset-name CODESET_NAME] [-p|--codeset-project CODESET_PROJECT] [-s|--status STATUS]",
+		Use:   "list-runs [-n|--name NAME] [-p|--codeset-project CODESET_PROJECT] [-c|--codeset-name CODESET_NAME] [-s|--status STATUS]",
 		Short: "Lists one or more workflow runs",
 		Long:  `Prints a table of the most important information about workflow runs. You can filter the list by the workflow name, codeset name, codeset project or status.`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -87,8 +87,8 @@ func newSubCmdListRuns(gOpt *common.GlobalOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.name, "name", "n", "", "filter workflow runs by the workflow name")
-	cmd.Flags().StringVarP(&o.codesetName, "codeset-name", "c", "", "filter workflow runs by the codeset name")
 	cmd.Flags().StringVarP(&o.codesetProject, "codeset-project", "p", "", "filter workflow runs by the codeset project")
+	cmd.Flags().StringVarP(&o.codesetName, "codeset-name", "c", "", "filter workflow runs by the codeset name")
 	cmd.Flags().StringVarP(&o.status, "status", "s", "", "filter workflow runs by the workflow run status")
 	o.format.AddMultiValueFormattingFlags(cmd)
 
@@ -100,7 +100,7 @@ func (o *listRunsOptions) validate() error {
 }
 
 func (o *listRunsOptions) run() error {
-	wfRuns, err := o.WorkflowClient.ListRuns(o.name, o.codesetName, o.codesetProject, o.status)
+	wfRuns, err := o.WorkflowClient.ListRuns(o.name, o.codesetProject, o.codesetName, o.status)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/workflow/unassign.go
+++ b/pkg/cli/workflow/unassign.go
@@ -1,0 +1,61 @@
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+)
+
+type unassignOptions struct {
+	client.Clients
+	global         *common.GlobalOptions
+	name           string
+	codesetName    string
+	codesetProject string
+}
+
+func newUnassignOptions(o *common.GlobalOptions) *unassignOptions {
+	return &unassignOptions{global: o}
+}
+
+func newSubCmdUnassign(gOpt *common.GlobalOptions) *cobra.Command {
+	o := newUnassignOptions(gOpt)
+	cmd := &cobra.Command{
+		Use:   "unassign {-n|--name NAME} {-p|--codeset-project CODESET_PROJECT}  {-c|--codeset-name CODESET_NAME}",
+		Short: "Unassign a workflow from a codeset",
+		Long:  `Removes the assignment between a workflow and a codeset.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
+			common.CheckErr(o.validate())
+			common.CheckErr(o.run())
+		},
+		Args: cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().StringVarP(&o.name, "name", "n", "", "workflow name")
+	cmd.Flags().StringVarP(&o.codesetProject, "codeset-project", "p", "", "name of the project to which the codeset belongs")
+	cmd.Flags().StringVarP(&o.codesetName, "codeset-name", "c", "", "name of the codeset assigned to the workflow")
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("codeset-project")
+	cmd.MarkFlagRequired("codeset-name")
+
+	return cmd
+}
+
+func (o *unassignOptions) validate() error {
+	return nil
+}
+
+func (o *unassignOptions) run() error {
+	err := o.WorkflowClient.Unassign(o.name, o.codesetProject, o.codesetName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Workflow %q unassigned from codeset \"%s/%s\"\n", o.name, o.codesetProject, o.codesetName)
+
+	return nil
+}

--- a/pkg/core/gitea/client.go
+++ b/pkg/core/gitea/client.go
@@ -238,7 +238,7 @@ func (gac giteaAdminClient) CreateRepoWebhook(org, name string, listenerURL *str
 		url := hook.Config["url"]
 		if url == *listenerURL {
 			gac.logger.Printf("Webhook for '%s' already exists", name)
-			return nil, nil
+			return &hook.ID, nil
 		}
 	}
 

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -41,9 +41,9 @@ func (s *workflowsrvc) List(ctx context.Context, w *workflow.ListPayload) (res [
 	return s.store.GetWorkflows(ctx, w.Name), nil
 }
 
-// Register a new Workflow.
-func (s *workflowsrvc) Register(ctx context.Context, w *workflow.Workflow) (res *workflow.Workflow, err error) {
-	s.logger.Print("workflow.register")
+// Create a new Workflow.
+func (s *workflowsrvc) Create(ctx context.Context, w *workflow.Workflow) (res *workflow.Workflow, err error) {
+	s.logger.Print("workflow.create")
 	err = s.backend.CreateWorkflow(ctx, s.logger, w)
 	if err != nil {
 		s.logger.Print(err)

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -230,10 +230,12 @@ func (s *workflowsrvc) unassignCodesetFromWorkflow(ctx context.Context, workflow
 		return workflow.MakeNotFound(err)
 	}
 
-	err = s.codesetStore.DeleteWebhook(ctx, codeset, assignment.WebhookID)
-	if err != nil {
-		s.logger.Print(err)
-		return err
+	if assignment.WebhookID != nil {
+		err = s.codesetStore.DeleteWebhook(ctx, codeset, assignment.WebhookID)
+		if err != nil {
+			s.logger.Print(err)
+			return err
+		}
 	}
 
 	if len(s.store.GetAssignedCodesets(ctx, workflowName)) == 1 {


### PR DESCRIPTION
- API: change workflow register to workflow create
- fix: when creating a webhook if it already exists return its ID instead of nil
- CLI: fix the order of codeset name and project parameters to be the same for all commands that needs it
- CLI: Implements the workflow unassign and delete commands.