### PR TITLE
fix: listing workflow runs just after assign fails

### DIFF
--- a/pkg/cli/workflow/list_runs.go
+++ b/pkg/cli/workflow/list_runs.go
@@ -27,13 +27,7 @@ type listRunsOptions struct {
 
 func formatRunDuration(object interface{}, column string, field interface{}) string {
 	if wr, ok := object.(*workflow.WorkflowRun); ok {
-		layout := time.RFC3339
-		startTime, _ := time.Parse(layout, *wr.StartTime)
-		completionTime := time.Time{}
-		if wr.CompletionTime != nil {
-			completionTime, _ = time.Parse(layout, *wr.CompletionTime)
-		}
-		return formatted.Duration(&v1.Time{Time: startTime}, &v1.Time{Time: completionTime})
+		return formatDuration(wr.StartTime, wr.CompletionTime)
 	}
 	return ""
 }
@@ -54,10 +48,12 @@ func formatRunWorkflowRef(object interface{}, column string, field interface{}) 
 
 func formatRunStartTime(object interface{}, column string, field interface{}) string {
 	if wr, ok := object.(*workflow.WorkflowRun); ok {
-		startTime, _ := time.Parse(time.RFC3339, *wr.StartTime)
-		return formatted.Age(&v1.Time{Time: startTime}, clockwork.NewRealClock())
+		if wr.StartTime != nil {
+			startTime, _ := time.Parse(time.RFC3339, *wr.StartTime)
+			return formatted.Age(&v1.Time{Time: startTime}, clockwork.NewRealClock())
+		}
 	}
-	return ""
+	return "---"
 }
 
 func newListRunsOptions(o *common.GlobalOptions) (res *listRunsOptions) {

--- a/pkg/cli/workflow/utils.go
+++ b/pkg/cli/workflow/utils.go
@@ -16,14 +16,20 @@ func formatDesc(desc string) string {
 }
 
 func formatAge(startTime *string) string {
-	st, _ := time.Parse(time.RFC3339, *startTime)
-	return formatted.Age(&v1.Time{Time: st}, clockwork.NewRealClock())
+	if startTime != nil {
+		st, _ := time.Parse(time.RFC3339, *startTime)
+		return formatted.Age(&v1.Time{Time: st}, clockwork.NewRealClock())
+	}
+	return "---"
 }
 
 func formatDuration(startTime, completionTime *string) string {
 	layout := time.RFC3339
-	st, _ := time.Parse(layout, *startTime)
+	st := time.Time{}
 	ct := time.Time{}
+	if startTime != nil {
+		st, _ = time.Parse(layout, *startTime)
+	}
 	if completionTime != nil {
 		ct, _ = time.Parse(layout, *completionTime)
 	}

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -570,11 +570,15 @@ func getInputCodesetPath(inputs []*workflow.WorkflowStepInput) string {
 }
 
 func (w *WorkflowBackend) toWorkflowRun(wf workflow.Workflow, p v1beta1.PipelineRun) *workflow.WorkflowRun {
-	startTime := p.Status.StartTime.Format(time.RFC3339)
+
 	wfr := workflow.WorkflowRun{
 		Name:        &p.ObjectMeta.Name,
 		WorkflowRef: &wf.Name,
-		StartTime:   &startTime,
+	}
+
+	if p.Status.StartTime != nil {
+		startTime := p.Status.StartTime.Format(time.RFC3339)
+		wfr.StartTime = &startTime
 	}
 
 	if p.Status.CompletionTime != nil {
@@ -656,7 +660,6 @@ func contains(slice []string, item string) bool {
 }
 
 func (w *WorkflowBackend) tektonDeleteIfError(ctx context.Context, log *log.Logger, err *error, tektonWorkload interface{}) {
-	fmt.Print(*err)
 	if *err != nil {
 		switch tw := tektonWorkload.(type) {
 		case *v1alpha1.TriggerTemplate:


### PR DESCRIPTION
When listing workflow runs just after a workflow run starts it fails
as there is no start time on it yet, resulting in a nil pointer dereference
error.

This change adds checks for the start time before trying to reference
it.