### PR TITLE
fix: set correct version when compiling on branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,23 +16,18 @@ LDFLAGS:= -w -s
 PKG_PATH=github.com/fuseml/fuseml-core/pkg
 
 GIT_COMMIT = $(shell git rev-parse --short=8 HEAD)
-GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD|grep -v HEAD)
-GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+GIT_REF = $(shell git symbolic-ref -q --short HEAD || git describe --tags --abbrev=0 --exact-match)
 BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 ifdef VERSION
 	BINARY_VERSION = $(VERSION)
 else
 # Use `dev` as a default version value when compiling in the main branch
-ifeq ($(GIT_BRANCH),main)
+ifeq ($(GIT_REF),main)
 	BINARY_VERSION = dev
-# Use the branch name as a default version value when compiling in another branch
+# Use the reference name as a default version value when compiling in another branch/tag,
 else
-	BINARY_VERSION = $(GIT_BRANCH)
-endif
-ifneq ($(GIT_TAG),)
-	BINARY_VERSION = $(GIT_TAG)
-else
+	BINARY_VERSION = $(GIT_REF)
 endif
 endif
 


### PR DESCRIPTION
Currently, the binaries version are always being resolved to the latest
tag, independent on the branch/tag where the code is being compiled.

This change fixes that by trying to resolve the version from the branch
name and, if not possible, then use the tag name.