### PR TITLE
Implement support for Projects and defaults for user, password and codeset

### DIFF
--- a/cmd/fuseml_core/grpc.go
+++ b/cmd/fuseml_core/grpc.go
@@ -13,10 +13,13 @@ import (
 	applicationsvr "github.com/fuseml/fuseml-core/gen/grpc/application/server"
 	codesetpb "github.com/fuseml/fuseml-core/gen/grpc/codeset/pb"
 	codesetsvr "github.com/fuseml/fuseml-core/gen/grpc/codeset/server"
+	projectpb "github.com/fuseml/fuseml-core/gen/grpc/project/pb"
+	projectsvr "github.com/fuseml/fuseml-core/gen/grpc/project/server"
 	runnablepb "github.com/fuseml/fuseml-core/gen/grpc/runnable/pb"
 	runnablesvr "github.com/fuseml/fuseml-core/gen/grpc/runnable/server"
 	workflowpb "github.com/fuseml/fuseml-core/gen/grpc/workflow/pb"
 	workflowsvr "github.com/fuseml/fuseml-core/gen/grpc/workflow/server"
+	project "github.com/fuseml/fuseml-core/gen/project"
 	runnable "github.com/fuseml/fuseml-core/gen/runnable"
 	workflow "github.com/fuseml/fuseml-core/gen/workflow"
 
@@ -29,7 +32,7 @@ import (
 
 // handleGRPCServer starts configures and starts a gRPC server on the given
 // URL. It shuts down the server if any error is received in the error channel.
-func handleGRPCServer(ctx context.Context, u *url.URL, runnableEndpoints *runnable.Endpoints, codesetEndpoints *codeset.Endpoints, workflowEndpoints *workflow.Endpoints, applicationEndpoints *application.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {
+func handleGRPCServer(ctx context.Context, u *url.URL, runnableEndpoints *runnable.Endpoints, codesetEndpoints *codeset.Endpoints, projectEndpoints *project.Endpoints, workflowEndpoints *workflow.Endpoints, applicationEndpoints *application.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {
 	// Setup goa log adapter.
 	var (
 		adapter middleware.Logger
@@ -46,12 +49,14 @@ func handleGRPCServer(ctx context.Context, u *url.URL, runnableEndpoints *runnab
 		applicationServer *applicationsvr.Server
 		runnableServer    *runnablesvr.Server
 		codesetServer     *codesetsvr.Server
+		projectServer     *projectsvr.Server
 		workflowServer    *workflowsvr.Server
 	)
 	{
 		applicationServer = applicationsvr.New(applicationEndpoints, nil)
 		runnableServer = runnablesvr.New(runnableEndpoints, nil)
 		codesetServer = codesetsvr.New(codesetEndpoints, nil)
+		projectServer = projectsvr.New(projectEndpoints, nil)
 		workflowServer = workflowsvr.New(workflowEndpoints, nil)
 	}
 
@@ -67,6 +72,7 @@ func handleGRPCServer(ctx context.Context, u *url.URL, runnableEndpoints *runnab
 	applicationpb.RegisterApplicationServer(srv, applicationServer)
 	runnablepb.RegisterRunnableServer(srv, runnableServer)
 	codesetpb.RegisterCodesetServer(srv, codesetServer)
+	projectpb.RegisterProjectServer(srv, projectServer)
 	workflowpb.RegisterWorkflowServer(srv, workflowServer)
 
 	for svc, info := range srv.GetServiceInfo() {

--- a/cmd/fuseml_core/http.go
+++ b/cmd/fuseml_core/http.go
@@ -16,9 +16,11 @@ import (
 	applicationsvr "github.com/fuseml/fuseml-core/gen/http/application/server"
 	codesetsvr "github.com/fuseml/fuseml-core/gen/http/codeset/server"
 	openapisvr "github.com/fuseml/fuseml-core/gen/http/openapi/server"
+	projectsvr "github.com/fuseml/fuseml-core/gen/http/project/server"
 	runnablesvr "github.com/fuseml/fuseml-core/gen/http/runnable/server"
 	versionsvr "github.com/fuseml/fuseml-core/gen/http/version/server"
 	workflowsvr "github.com/fuseml/fuseml-core/gen/http/workflow/server"
+	project "github.com/fuseml/fuseml-core/gen/project"
 	runnable "github.com/fuseml/fuseml-core/gen/runnable"
 	"github.com/fuseml/fuseml-core/gen/version"
 	workflow "github.com/fuseml/fuseml-core/gen/workflow"
@@ -31,7 +33,7 @@ import (
 
 // handleHTTPServer starts configures and starts a HTTP server on the given
 // URL. It shuts down the server if any error is received in the error channel.
-func handleHTTPServer(ctx context.Context, u *url.URL, versionEndpoints *version.Endpoints, runnableEndpoints *runnable.Endpoints, codesetEndpoints *codeset.Endpoints, workflowEndpoints *workflow.Endpoints, applicationEndpoints *application.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {
+func handleHTTPServer(ctx context.Context, u *url.URL, versionEndpoints *version.Endpoints, runnableEndpoints *runnable.Endpoints, codesetEndpoints *codeset.Endpoints, projectEndpoints *project.Endpoints, workflowEndpoints *workflow.Endpoints, applicationEndpoints *application.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {
 	// Setup goa log adapter.
 	var (
 		adapter middleware.Logger
@@ -65,6 +67,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, versionEndpoints *version
 		applicationServer *applicationsvr.Server
 		runnableServer    *runnablesvr.Server
 		codesetServer     *codesetsvr.Server
+		projectServer     *projectsvr.Server
 		openapiServer     *openapisvr.Server
 		workflowServer    *workflowsvr.Server
 	)
@@ -74,6 +77,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, versionEndpoints *version
 		applicationServer = applicationsvr.New(applicationEndpoints, mux, dec, enc, eh, nil)
 		runnableServer = runnablesvr.New(runnableEndpoints, mux, dec, enc, eh, nil)
 		codesetServer = codesetsvr.New(codesetEndpoints, mux, dec, enc, eh, nil)
+		projectServer = projectsvr.New(projectEndpoints, mux, dec, enc, eh, nil)
 		openapiServer = openapisvr.New(nil, mux, dec, enc, eh, nil)
 		workflowServer = workflowsvr.New(workflowEndpoints, mux, dec, enc, eh, nil)
 		if debug {
@@ -82,6 +86,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, versionEndpoints *version
 				applicationServer,
 				runnableServer,
 				codesetServer,
+				projectServer,
 				openapiServer,
 				workflowServer,
 			}
@@ -93,6 +98,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, versionEndpoints *version
 	applicationsvr.Mount(mux, applicationServer)
 	runnablesvr.Mount(mux, runnableServer)
 	codesetsvr.Mount(mux, codesetServer)
+	projectsvr.Mount(mux, projectServer)
 	openapisvr.Mount(mux)
 	workflowsvr.Mount(mux, workflowServer)
 
@@ -117,6 +123,9 @@ func handleHTTPServer(ctx context.Context, u *url.URL, versionEndpoints *version
 		logger.Printf("HTTP %q mounted on %s %s", m.Method, m.Verb, m.Pattern)
 	}
 	for _, m := range codesetServer.Mounts {
+		logger.Printf("HTTP %q mounted on %s %s", m.Method, m.Verb, m.Pattern)
+	}
+	for _, m := range projectServer.Mounts {
 		logger.Printf("HTTP %q mounted on %s %s", m.Method, m.Verb, m.Pattern)
 	}
 	for _, m := range openapiServer.Mounts {

--- a/cmd/fuseml_core/main.go
+++ b/cmd/fuseml_core/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/fuseml/fuseml-core/gen/application"
 	"github.com/fuseml/fuseml-core/gen/codeset"
+	"github.com/fuseml/fuseml-core/gen/project"
 	"github.com/fuseml/fuseml-core/gen/runnable"
 	"github.com/fuseml/fuseml-core/gen/version"
 	"github.com/fuseml/fuseml-core/gen/workflow"
@@ -58,14 +59,17 @@ func main() {
 		applicationSvc application.Service
 		runnableSvc    runnable.Service
 		codesetSvc     codeset.Service
+		projectSvc     project.Service
 		workflowSvc    workflow.Service
 	)
 	{
 		versionSvc = svc.NewVersionService(logger)
 		codesetStore := core.NewGitCodesetStore(gitAdmin)
+		projectStore := core.NewGitProjectStore(gitAdmin)
 		applicationSvc = svc.NewApplicationService(logger, core.NewApplicationStore())
 		runnableSvc = svc.NewRunnableService(logger, core.NewRunnableStore())
 		codesetSvc = svc.NewCodesetService(logger, codesetStore)
+		projectSvc = svc.NewProjectService(logger, projectStore)
 		workflowSvc, err = svc.NewWorkflowService(logger, core.NewWorkflowStore(), codesetStore)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Failed to initialize Workflow service:", err.Error())
@@ -80,6 +84,7 @@ func main() {
 		applicationEndpoints *application.Endpoints
 		runnableEndpoints    *runnable.Endpoints
 		codesetEndpoints     *codeset.Endpoints
+		projectEndpoints     *project.Endpoints
 		workflowEndpoints    *workflow.Endpoints
 	)
 	{
@@ -87,6 +92,7 @@ func main() {
 		applicationEndpoints = application.NewEndpoints(applicationSvc)
 		runnableEndpoints = runnable.NewEndpoints(runnableSvc)
 		codesetEndpoints = codeset.NewEndpoints(codesetSvc)
+		projectEndpoints = project.NewEndpoints(projectSvc)
 		workflowEndpoints = workflow.NewEndpoints(workflowSvc)
 	}
 
@@ -131,7 +137,14 @@ func main() {
 			} else if u.Port() == "" {
 				u.Host = net.JoinHostPort(u.Host, "80")
 			}
-			handleHTTPServer(ctx, u, versionEndpoints, runnableEndpoints, codesetEndpoints, workflowEndpoints, applicationEndpoints,
+			handleHTTPServer(
+				ctx, u,
+				versionEndpoints,
+				runnableEndpoints,
+				codesetEndpoints,
+				projectEndpoints,
+				workflowEndpoints,
+				applicationEndpoints,
 				&wg, errc, logger, *dbgF)
 		}
 
@@ -158,7 +171,14 @@ func main() {
 			} else if u.Port() == "" {
 				u.Host = net.JoinHostPort(u.Host, "8080")
 			}
-			handleGRPCServer(ctx, u, runnableEndpoints, codesetEndpoints, workflowEndpoints, applicationEndpoints, &wg, errc, logger, *dbgF)
+			handleGRPCServer(
+				ctx, u,
+				runnableEndpoints,
+				codesetEndpoints,
+				projectEndpoints,
+				workflowEndpoints,
+				applicationEndpoints,
+				&wg, errc, logger, *dbgF)
 		}
 
 	case "prod":
@@ -185,7 +205,14 @@ func main() {
 			} else if u.Port() == "" {
 				u.Host = net.JoinHostPort(u.Host, "80")
 			}
-			handleHTTPServer(ctx, u, versionEndpoints, runnableEndpoints, codesetEndpoints, workflowEndpoints, applicationEndpoints,
+			handleHTTPServer(
+				ctx, u,
+				versionEndpoints,
+				runnableEndpoints,
+				codesetEndpoints,
+				projectEndpoints,
+				workflowEndpoints,
+				applicationEndpoints,
 				&wg, errc, logger, *dbgF)
 		}
 
@@ -212,7 +239,14 @@ func main() {
 			} else if u.Port() == "" {
 				u.Host = net.JoinHostPort(u.Host, "8080")
 			}
-			handleGRPCServer(ctx, u, runnableEndpoints, codesetEndpoints, workflowEndpoints, applicationEndpoints, &wg, errc, logger, *dbgF)
+			handleGRPCServer(
+				ctx, u,
+				runnableEndpoints,
+				codesetEndpoints,
+				projectEndpoints,
+				workflowEndpoints,
+				applicationEndpoints,
+				&wg, errc, logger, *dbgF)
 		}
 
 	default:

--- a/design/api.go
+++ b/design/api.go
@@ -15,7 +15,7 @@ var _ = API("fuseml", func() {
 		Description("fuseml-core hosts the core services")
 
 		// List the services hosted by this server.
-		Services("application", "runnable", "codeset", "workflow", "openapi")
+		Services("application", "runnable", "codeset", "project", "workflow", "openapi")
 
 		// List the Hosts and their transport URLs.
 		Host("dev", func() {

--- a/design/project.go
+++ b/design/project.go
@@ -56,6 +56,45 @@ var _ = Service("project", func() {
 		})
 	})
 
+	Method("create", func() {
+		Description("Create a new Project.")
+
+		Payload(func() {
+			Field(1, "name", String, "The name of the Project", func() {
+				Example("mlflow-project-01")
+				Pattern(`^[A-Za-z0-9_][A-Za-z0-9-_]*$`)
+			})
+			Field(2, "description", String, "Project description", func() {
+				Example("Set of MLFlow applications")
+				Default("")
+			})
+			Required("name")
+		})
+
+		Error("BadRequest", func() {
+			Description("If the project does not have the required fields, should return 400 Bad Request.")
+		})
+		Error("Conflict", func() {
+			Description("If a project with the same name already exists, should return 409 Conflict.")
+		})
+		Result(Project)
+
+		HTTP(func() {
+			POST("/projects")
+			Param("name")
+			Param("description")
+			Response(StatusCreated)
+			Response("BadRequest", StatusBadRequest)
+			Response("Conflict", StatusConflict)
+		})
+
+		GRPC(func() {
+			Response(CodeOK)
+			Response("BadRequest", CodeInvalidArgument)
+			Response("Conflict", CodeAlreadyExists)
+		})
+	})
+
 	Method("delete", func() {
 		Description("Delete a FuseML Project.")
 

--- a/design/project.go
+++ b/design/project.go
@@ -1,0 +1,108 @@
+package design
+
+import (
+	. "goa.design/goa/v3/dsl"
+)
+
+var _ = Service("project", func() {
+	Description("The project service performs operations on Projects.")
+
+	Method("list", func() {
+		Description("Retrieve information about FuseML Projects.")
+
+		Result(ArrayOf(Project), "Return all Projects.")
+
+		HTTP(func() {
+			GET("/projects")
+			Response(StatusOK)
+		})
+
+		GRPC(func() {
+			Response(CodeOK)
+		})
+
+	})
+
+	Method("get", func() {
+		Description("Retrieve a Project from FuseML.")
+
+		Payload(func() {
+			Field(1, "name", String, "Project name", func() {
+				Example("mlflow-project-01")
+			})
+			Required("name")
+		})
+
+		Error("BadRequest", func() {
+			Description("If name is not given, should return 400 Bad Request.")
+		})
+		Error("NotFound", func() {
+			Description("If there is no project with the given name, should return 404 Not Found.")
+		})
+
+		Result(Project)
+
+		HTTP(func() {
+			GET("/projects/{name}")
+			Response(StatusOK)
+			Response("BadRequest", StatusBadRequest)
+			Response("NotFound", StatusNotFound)
+		})
+
+		GRPC(func() {
+			Response(CodeOK)
+			Response("BadRequest", CodeInvalidArgument)
+			Response("NotFound", CodeNotFound)
+		})
+	})
+
+	Method("delete", func() {
+		Description("Delete a FuseML Project.")
+
+		Payload(func() {
+			Field(1, "name", String, "Project name", func() {
+				Example("mlflow-project-01")
+			})
+			Required("name")
+		})
+
+		Error("BadRequest", func() {
+			Description("If name is not given, should return 400 Bad Request.")
+		})
+
+		HTTP(func() {
+			DELETE("/projects/{name}")
+			Response(StatusNoContent)
+			Response("BadRequest", StatusBadRequest)
+		})
+		GRPC(func() {
+			Response(CodeOK)
+			Response("BadRequest", CodeInvalidArgument)
+		})
+	})
+})
+
+// Project describes the Project
+var Project = Type("Project", func() {
+
+	Field(1, "name", String, "The name of the Project", func() {
+		Example("mlflow-project-01")
+	})
+	Field(2, "users", ArrayOf(User), "Users assigned to the Project")
+	Field(3, "description", String, "Project description", func() {
+		Example("Set of MLFlow applications")
+		Default("")
+	})
+	Required("name")
+})
+
+// User describes the user assigned to the project
+var User = Type("User", func() {
+	Field(1, "name", String, "User name", func() {
+		Example("fuseml-mlflow-project-01")
+	})
+	Field(2, "email", String, "User email", func() {
+		Example("fuseml-mlflow-project-01@fuseml.org")
+	})
+	Required("name", "email")
+})

--- a/pkg/cli/client/common.go
+++ b/pkg/cli/client/common.go
@@ -10,6 +10,7 @@ import (
 
 	applicationc "github.com/fuseml/fuseml-core/gen/http/application/client"
 	codesetc "github.com/fuseml/fuseml-core/gen/http/codeset/client"
+	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
 	runnablec "github.com/fuseml/fuseml-core/gen/http/runnable/client"
 	yaml "github.com/goccy/go-yaml"
 	goahttp "goa.design/goa/v3/http"
@@ -20,6 +21,7 @@ type Clients struct {
 	CodesetClient     *codesetc.Client
 	ApplicationClient *applicationc.Client
 	WorkflowClient    *WorkflowClient
+	ProjectClient     *projectc.Client
 	RunnableClient    *runnablec.Client
 	VersionClient     *VersionClient
 }
@@ -50,11 +52,12 @@ func (c *Clients) InitializeClients(URL string, timeout int, verbose bool) error
 		doer = goahttp.NewDebugDoer(doer)
 	}
 
-	c.CodesetClient = codesetc.NewClient(scheme, host, doer, encoder, decoder, verbose)
 	c.ApplicationClient = applicationc.NewClient(scheme, host, doer, encoder, decoder, verbose)
-	c.WorkflowClient = NewWorkflowClient(scheme, host, doer, encoder, decoder, verbose)
+	c.CodesetClient = codesetc.NewClient(scheme, host, doer, encoder, decoder, verbose)
+	c.ProjectClient = projectc.NewClient(scheme, host, doer, encoder, decoder, verbose)
 	c.RunnableClient = runnablec.NewClient(scheme, host, doer, encoder, decoder, verbose)
 	c.VersionClient = NewVersionClient(scheme, host, doer, encoder, decoder, verbose)
+	c.WorkflowClient = NewWorkflowClient(scheme, host, doer, encoder, decoder, verbose)
 
 	return nil
 }

--- a/pkg/cli/client/common.go
+++ b/pkg/cli/client/common.go
@@ -10,7 +10,6 @@ import (
 
 	applicationc "github.com/fuseml/fuseml-core/gen/http/application/client"
 	codesetc "github.com/fuseml/fuseml-core/gen/http/codeset/client"
-	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
 	runnablec "github.com/fuseml/fuseml-core/gen/http/runnable/client"
 	yaml "github.com/goccy/go-yaml"
 	goahttp "goa.design/goa/v3/http"
@@ -21,7 +20,7 @@ type Clients struct {
 	CodesetClient     *codesetc.Client
 	ApplicationClient *applicationc.Client
 	WorkflowClient    *WorkflowClient
-	ProjectClient     *projectc.Client
+	ProjectClient     *ProjectClient
 	RunnableClient    *runnablec.Client
 	VersionClient     *VersionClient
 }
@@ -54,7 +53,7 @@ func (c *Clients) InitializeClients(URL string, timeout int, verbose bool) error
 
 	c.ApplicationClient = applicationc.NewClient(scheme, host, doer, encoder, decoder, verbose)
 	c.CodesetClient = codesetc.NewClient(scheme, host, doer, encoder, decoder, verbose)
-	c.ProjectClient = projectc.NewClient(scheme, host, doer, encoder, decoder, verbose)
+	c.ProjectClient = NewProjectClient(scheme, host, doer, encoder, decoder, verbose)
 	c.RunnableClient = runnablec.NewClient(scheme, host, doer, encoder, decoder, verbose)
 	c.VersionClient = NewVersionClient(scheme, host, doer, encoder, decoder, verbose)
 	c.WorkflowClient = NewWorkflowClient(scheme, host, doer, encoder, decoder, verbose)

--- a/pkg/cli/client/project.go
+++ b/pkg/cli/client/project.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"context"
+	"net/http"
+
+	goahttp "goa.design/goa/v3/http"
+
+	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
+	"github.com/fuseml/fuseml-core/gen/project"
+)
+
+// ProjectClient holds a client for Project
+type ProjectClient struct {
+	c *projectc.Client
+}
+
+// NewProjectClient initializes a ProjectClient
+func NewProjectClient(scheme string, host string, doer goahttp.Doer, encoder func(*http.Request) goahttp.Encoder,
+	decoder func(*http.Response) goahttp.Decoder, verbose bool) *ProjectClient {
+	pc := &ProjectClient{projectc.NewClient(scheme, host, doer, encoder, decoder, verbose)}
+	return pc
+}
+
+// Create a new Project.
+func (pc *ProjectClient) Create(name, desc string) (*project.Project, error) {
+	request, err := projectc.BuildCreatePayload(name, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := pc.c.Create()(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.(*project.Project), nil
+}
+
+// Delete a Project and its assignments.
+func (pc *ProjectClient) Delete(name string) (err error) {
+	request, err := projectc.BuildDeletePayload(name)
+	if err != nil {
+		return
+	}
+
+	_, err = pc.c.Delete()(context.Background(), request)
+	return
+}
+
+// Get a Project.
+func (pc *ProjectClient) Get(name string) (*project.Project, error) {
+	request, err := projectc.BuildGetPayload(name)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := pc.c.Get()(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.(*project.Project), nil
+}
+
+// List Projects.
+func (pc *ProjectClient) List() ([]*project.Project, error) {
+	response, err := pc.c.List()(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return response.([]*project.Project), nil
+}

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fuseml/fuseml-core/pkg/cli/application"
 	"github.com/fuseml/fuseml-core/pkg/cli/codeset"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/fuseml/fuseml-core/pkg/cli/project"
 	"github.com/fuseml/fuseml-core/pkg/cli/runnable"
 	"github.com/fuseml/fuseml-core/pkg/cli/version"
 	"github.com/fuseml/fuseml-core/pkg/cli/workflow"
@@ -45,6 +46,7 @@ func NewCmdRoot() *cobra.Command {
 
 	cmd.AddCommand(version.NewCmdVersion(o))
 	cmd.AddCommand(codeset.NewCmdCodeset(o))
+	cmd.AddCommand(project.NewCmdProject(o))
 	cmd.AddCommand(runnable.NewCmdRunnable(o))
 	cmd.AddCommand(workflow.NewCmdWorkflow(o))
 	cmd.AddCommand(application.NewCmdApplication(o))

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -106,6 +106,12 @@ func defaultForMissingFlagPossible(flag, defaultKey string) bool {
 			return true
 		}
 	}
+	if defaultKey == "CurrentPassword" && flag == "password" {
+		return true
+	}
+	if defaultKey == "CurrentUser" && flag == "user" {
+		return true
+	}
 	return false
 }
 
@@ -127,6 +133,12 @@ func bindFlags(cmd *cobra.Command) {
 		// use CurrentCodeset as a backup for missing codeset name flag
 		if !f.Changed && defaultForMissingFlagPossible(f.Name, "CurrentCodeset") {
 			cmd.Flags().Set(f.Name, viper.GetString("CurrentCodeset"))
+		}
+		if !f.Changed && defaultForMissingFlagPossible(f.Name, "CurrentPassword") {
+			cmd.Flags().Set(f.Name, viper.GetString("CurrentPassword"))
+		}
+		if !f.Changed && defaultForMissingFlagPossible(f.Name, "CurrentUser") {
+			cmd.Flags().Set(f.Name, viper.GetString("CurrentUser"))
 		}
 	})
 

--- a/pkg/cli/codeset/cmd.go
+++ b/pkg/cli/codeset/cmd.go
@@ -17,6 +17,7 @@ func NewCmdCodeset(c *common.GlobalOptions) *cobra.Command {
 	cmd.AddCommand(NewSubCmdCodesetGet(c))
 	cmd.AddCommand(NewSubCmdCodesetList(c))
 	cmd.AddCommand(NewSubCmdCodesetDelete(c))
+	cmd.AddCommand(NewSubCmdCodesetSet(c))
 
 	return cmd
 }

--- a/pkg/cli/codeset/set.go
+++ b/pkg/cli/codeset/set.go
@@ -1,0 +1,66 @@
+package codeset
+
+import (
+	"fmt"
+
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// SetOptions holds the options for 'codeset set' sub command
+type SetOptions struct {
+	global *common.GlobalOptions
+	format *common.FormattingOptions
+	Name   string
+}
+
+// NewSetOptions creates a CodesetSetOptions struct
+func NewSetOptions(o *common.GlobalOptions) *SetOptions {
+	res := &SetOptions{global: o}
+	res.format = common.NewSingleValueFormattingOptions()
+	return res
+}
+
+// NewSubCmdCodesetSet creates and returns the cobra command for the `codeset set` CLI command
+func NewSubCmdCodesetSet(gOpt *common.GlobalOptions) *cobra.Command {
+
+	o := NewSetOptions(gOpt)
+
+	cmd := &cobra.Command{
+		Use:   `set {-n|--name NAME}`,
+		Short: "Set current codeset.",
+		Long:  `Set codeset as a current one`,
+		Run: func(cmd *cobra.Command, args []string) {
+			common.CheckErr(o.validate())
+			common.CheckErr(o.run())
+		},
+		Args: cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "codeset name")
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
+	cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func (o *SetOptions) validate() error {
+	return nil
+}
+
+func (o *SetOptions) run() error {
+
+	if viper.GetString("CurrentCodeset") == o.Name {
+		fmt.Printf("Codeset %s is already current one.\n", o.Name)
+		return nil
+	}
+
+	viper.Set("CurrentCodeset", o.Name)
+
+	if err := viper.WriteConfig(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Current codeset set to %s.\n", o.Name)
+	return nil
+}

--- a/pkg/cli/common/global.go
+++ b/pkg/cli/common/global.go
@@ -19,6 +19,10 @@ type GlobalOptions struct {
 	Timeout int
 	// Verbose mode prints out additional information
 	Verbose bool
+	// CurrentProject says which project to use if "project" flag is not passed
+	CurrentProject string
+	// CurrentCodeset sets which codeset to use if the name is not provided
+	CurrentCodeset string
 }
 
 // Validate validates the global configuration

--- a/pkg/cli/git/git.go
+++ b/pkg/cli/git/git.go
@@ -48,8 +48,7 @@ func fetchRemoteRepository(path, target string) error {
 }
 
 // Push the code from local dir to remote repo
-// If username or password is not provided, use default values, but password
-// provided from env variable GITEA_PROJECT_PASSWORD has the highest priority.
+// If username or password is not provided, use default values
 func Push(org, name, location, gitURL string, uname, pass *string, debug bool) error {
 	log.Printf("Pushing the code to the git repository...")
 
@@ -87,10 +86,6 @@ func Push(org, name, location, gitURL string, uname, pass *string, debug bool) e
 	}
 	if pass != nil {
 		password = *pass
-	}
-	envPassword, exists := os.LookupEnv("FUSEML_PROJECT_PASSWORD")
-	if exists {
-		password = envPassword
 	}
 
 	u.User = url.UserPassword(username, password)

--- a/pkg/cli/project/cmd.go
+++ b/pkg/cli/project/cmd.go
@@ -1,0 +1,22 @@
+package project
+
+import (
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdProject creates and returns the cobra command that acts as a root for all other project CLI sub-commands
+func NewCmdProject(c *common.GlobalOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Project management",
+		Long:  `Perform operations on projects`,
+	}
+
+	cmd.AddCommand(NewSubCmdProjectDelete(c))
+	cmd.AddCommand(NewSubCmdProjectGet(c))
+	cmd.AddCommand(NewSubCmdProjectList(c))
+	cmd.AddCommand(NewSubCmdProjectSet(c))
+
+	return cmd
+}

--- a/pkg/cli/project/cmd.go
+++ b/pkg/cli/project/cmd.go
@@ -13,6 +13,7 @@ func NewCmdProject(c *common.GlobalOptions) *cobra.Command {
 		Long:  `Perform operations on projects`,
 	}
 
+	cmd.AddCommand(NewSubCmdProjectCreate(c))
 	cmd.AddCommand(NewSubCmdProjectDelete(c))
 	cmd.AddCommand(NewSubCmdProjectGet(c))
 	cmd.AddCommand(NewSubCmdProjectList(c))

--- a/pkg/cli/project/create.go
+++ b/pkg/cli/project/create.go
@@ -1,10 +1,8 @@
 package project
 
 import (
-	"context"
 	"fmt"
 
-	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
@@ -55,12 +53,7 @@ func (o *CreateOptions) validate() error {
 }
 
 func (o *CreateOptions) run() error {
-	request, err := projectc.BuildCreatePayload(o.Name, o.Description)
-	if err != nil {
-		return err
-	}
-
-	_, err = o.ProjectClient.Create()(context.Background(), request)
+	_, err := o.ProjectClient.Create(o.Name, o.Description)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/project/create.go
+++ b/pkg/cli/project/create.go
@@ -1,0 +1,71 @@
+package project
+
+import (
+	"context"
+	"fmt"
+
+	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// CreateOptions holds the options for 'project get' sub command
+type CreateOptions struct {
+	client.Clients
+	global      *common.GlobalOptions
+	format      *common.FormattingOptions
+	Name        string
+	Description string
+}
+
+// NewCreateOptions creates a ProjectCreateOptions struct
+func NewCreateOptions(o *common.GlobalOptions) *CreateOptions {
+	res := &CreateOptions{global: o}
+	res.format = common.NewSingleValueFormattingOptions()
+	return res
+}
+
+// NewSubCmdProjectCreate creates and returns the cobra command for the `project get` CLI command
+func NewSubCmdProjectCreate(gOpt *common.GlobalOptions) *cobra.Command {
+
+	o := NewCreateOptions(gOpt)
+
+	cmd := &cobra.Command{
+		Use:   `create {-n|--name NAME} {-d|--desc DESCRIPTION} [flags]`,
+		Short: "Create projects.",
+		Long:  `Create new FuseML project`,
+		Run: func(cmd *cobra.Command, args []string) {
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
+			common.CheckErr(o.validate())
+			common.CheckErr(o.run())
+		},
+		Args: cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "project name")
+	cmd.Flags().StringVarP(&o.Description, "desc", "d", "", "project description")
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
+	cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func (o *CreateOptions) validate() error {
+	return nil
+}
+
+func (o *CreateOptions) run() error {
+	request, err := projectc.BuildCreatePayload(o.Name, o.Description)
+	if err != nil {
+		return err
+	}
+
+	_, err = o.ProjectClient.Create()(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Project %s successfully created.\n", o.Name)
+
+	return nil
+}

--- a/pkg/cli/project/delete.go
+++ b/pkg/cli/project/delete.go
@@ -1,10 +1,8 @@
 package project
 
 import (
-	"context"
 	"fmt"
 
-	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
@@ -49,12 +47,7 @@ func (o *DeleteOptions) validate() error {
 }
 
 func (o *DeleteOptions) run() error {
-	request, err := projectc.BuildDeletePayload(o.Name)
-	if err != nil {
-		return err
-	}
-
-	_, err = o.ProjectClient.Delete()(context.Background(), request)
+	err := o.ProjectClient.Delete(o.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/project/delete.go
+++ b/pkg/cli/project/delete.go
@@ -1,0 +1,65 @@
+package project
+
+import (
+	"context"
+	"fmt"
+
+	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// DeleteOptions holds the options for 'project delete' sub command
+type DeleteOptions struct {
+	client.Clients
+	global *common.GlobalOptions
+	Name   string
+}
+
+// NewDeleteOptions creates a ProjectDeleteOptions struct
+func NewDeleteOptions(o *common.GlobalOptions) *DeleteOptions {
+	return &DeleteOptions{global: o}
+}
+
+// NewSubCmdProjectDelete creates and returns the cobra command for the `project delete` CLI command
+func NewSubCmdProjectDelete(gOpt *common.GlobalOptions) *cobra.Command {
+
+	o := NewDeleteOptions(gOpt)
+
+	cmd := &cobra.Command{
+		Use:   `delete {-n|--name NAME}`,
+		Short: "Delete projects.",
+		Long:  `Delete a project from FuseML`,
+		Run: func(cmd *cobra.Command, args []string) {
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
+			common.CheckErr(o.validate())
+			common.CheckErr(o.run())
+		},
+		Args: cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "project name")
+	cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func (o *DeleteOptions) validate() error {
+	return nil
+}
+
+func (o *DeleteOptions) run() error {
+	request, err := projectc.BuildDeletePayload(o.Name)
+	if err != nil {
+		return err
+	}
+
+	_, err = o.ProjectClient.Delete()(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Project %s successfully deleted\n", o.Name)
+
+	return nil
+}

--- a/pkg/cli/project/get.go
+++ b/pkg/cli/project/get.go
@@ -1,10 +1,8 @@
 package project
 
 import (
-	"context"
 	"os"
 
-	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/client"
 	"github.com/fuseml/fuseml-core/pkg/cli/common"
 	"github.com/spf13/cobra"
@@ -53,17 +51,12 @@ func (o *GetOptions) validate() error {
 }
 
 func (o *GetOptions) run() error {
-	request, err := projectc.BuildGetPayload(o.Name)
+	project, err := o.ProjectClient.Get(o.Name)
 	if err != nil {
 		return err
 	}
 
-	response, err := o.ProjectClient.Get()(context.Background(), request)
-	if err != nil {
-		return err
-	}
-
-	o.format.FormatValue(os.Stdout, response)
+	o.format.FormatValue(os.Stdout, project)
 
 	return nil
 }

--- a/pkg/cli/project/get.go
+++ b/pkg/cli/project/get.go
@@ -1,0 +1,69 @@
+package project
+
+import (
+	"context"
+	"os"
+
+	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// GetOptions holds the options for 'project get' sub command
+type GetOptions struct {
+	client.Clients
+	global *common.GlobalOptions
+	format *common.FormattingOptions
+	Name   string
+}
+
+// NewGetOptions creates a ProjectGetOptions struct
+func NewGetOptions(o *common.GlobalOptions) *GetOptions {
+	res := &GetOptions{global: o}
+	res.format = common.NewSingleValueFormattingOptions()
+	return res
+}
+
+// NewSubCmdProjectGet creates and returns the cobra command for the `project get` CLI command
+func NewSubCmdProjectGet(gOpt *common.GlobalOptions) *cobra.Command {
+
+	o := NewGetOptions(gOpt)
+
+	cmd := &cobra.Command{
+		Use:   `get {-n|--name NAME}`,
+		Short: "Get projects.",
+		Long:  `Show details about a FuseML project`,
+		Run: func(cmd *cobra.Command, args []string) {
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
+			common.CheckErr(o.validate())
+			common.CheckErr(o.run())
+		},
+		Args: cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "project name")
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
+	cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func (o *GetOptions) validate() error {
+	return nil
+}
+
+func (o *GetOptions) run() error {
+	request, err := projectc.BuildGetPayload(o.Name)
+	if err != nil {
+		return err
+	}
+
+	response, err := o.ProjectClient.Get()(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	o.format.FormatValue(os.Stdout, response)
+
+	return nil
+}

--- a/pkg/cli/project/list.go
+++ b/pkg/cli/project/list.go
@@ -1,0 +1,83 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
+	project "github.com/fuseml/fuseml-core/gen/project"
+
+	"github.com/fuseml/fuseml-core/pkg/cli/client"
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+// ListOptions holds the options for 'project list' sub command
+type ListOptions struct {
+	client.Clients
+	global *common.GlobalOptions
+	format *common.FormattingOptions
+}
+
+// custom formatting handler used to format project users
+func formatUsers(object interface{}, column string, field interface{}) (formated string) {
+	if project, ok := object.(*project.Project); ok {
+		for _, user := range project.Users {
+			if formated != "" {
+				formated += "\n"
+			}
+			formated += fmt.Sprintf("- name: %s\n  email: %s", user.Name, user.Email)
+		}
+	}
+	return
+}
+
+// NewListOptions initializes a ListOptions struct
+func NewListOptions(o *common.GlobalOptions) (res *ListOptions) {
+	res = &ListOptions{global: o}
+	res.format = common.NewFormattingOptions(
+		[]string{"Name", "Description", "Users"},
+		[]table.SortBy{{Name: "Name", Mode: table.Asc}},
+		common.OutputFormatters{"Users": formatUsers},
+	)
+
+	return
+}
+
+// NewSubCmdProjectList creates and returns the cobra command for the `project list` CLI command
+func NewSubCmdProjectList(gOpt *common.GlobalOptions) *cobra.Command {
+
+	o := NewListOptions(gOpt)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all projects.",
+		Long:  `Retrieve information about Projects registered in FuseML`,
+		Run: func(cmd *cobra.Command, args []string) {
+			common.CheckErr(o.InitializeClients(gOpt.URL, gOpt.Timeout, gOpt.Verbose))
+			common.CheckErr(o.validate())
+			common.CheckErr(o.run())
+		},
+		Args: cobra.ExactArgs(0),
+	}
+	o.format.AddMultiValueFormattingFlags(cmd)
+
+	return cmd
+}
+
+func (o *ListOptions) validate() error {
+	return nil
+}
+
+func (o *ListOptions) run() error {
+	response, err := o.ProjectClient.List()(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+
+	o.format.FormatValue(os.Stdout, response)
+
+	return nil
+}

--- a/pkg/cli/project/list.go
+++ b/pkg/cli/project/list.go
@@ -1,11 +1,9 @@
 package project
 
 import (
-	"context"
 	"fmt"
 	"os"
 
-	projectc "github.com/fuseml/fuseml-core/gen/http/project/client"
 	project "github.com/fuseml/fuseml-core/gen/project"
 
 	"github.com/fuseml/fuseml-core/pkg/cli/client"
@@ -72,12 +70,12 @@ func (o *ListOptions) validate() error {
 }
 
 func (o *ListOptions) run() error {
-	response, err := o.ProjectClient.List()(context.Background(), nil)
+	projects, err := o.ProjectClient.List()
 	if err != nil {
 		return err
 	}
 
-	o.format.FormatValue(os.Stdout, response)
+	o.format.FormatValue(os.Stdout, projects)
 
 	return nil
 }

--- a/pkg/cli/project/set.go
+++ b/pkg/cli/project/set.go
@@ -1,0 +1,66 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// SetOptions holds the options for 'project set' sub command
+type SetOptions struct {
+	global *common.GlobalOptions
+	format *common.FormattingOptions
+	Name   string
+}
+
+// NewSetOptions creates a ProjectSetOptions struct
+func NewSetOptions(o *common.GlobalOptions) *SetOptions {
+	res := &SetOptions{global: o}
+	res.format = common.NewSingleValueFormattingOptions()
+	return res
+}
+
+// NewSubCmdProjectSet creates and returns the cobra command for the `project set` CLI command
+func NewSubCmdProjectSet(gOpt *common.GlobalOptions) *cobra.Command {
+
+	o := NewSetOptions(gOpt)
+
+	cmd := &cobra.Command{
+		Use:   `set {-n|--name NAME}`,
+		Short: "Set current project.",
+		Long:  `Set project as a current one`,
+		Run: func(cmd *cobra.Command, args []string) {
+			common.CheckErr(o.validate())
+			common.CheckErr(o.run())
+		},
+		Args: cobra.ExactArgs(0),
+	}
+
+	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "project name")
+	o.format.AddSingleValueFormattingFlags(cmd, common.FormatYAML)
+	cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func (o *SetOptions) validate() error {
+	return nil
+}
+
+func (o *SetOptions) run() error {
+
+	if viper.GetString("CurrentProject") == o.Name {
+		fmt.Printf("Project %s is already current one.\n", o.Name)
+		return nil
+	}
+
+	viper.Set("CurrentProject", o.Name)
+
+	if err := viper.WriteConfig(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Current project set to %s.\n", o.Name)
+	return nil
+}

--- a/pkg/core/codeset_store.go
+++ b/pkg/core/codeset_store.go
@@ -16,6 +16,9 @@ type GitAdmin interface {
 	GetRepositories(org, label *string) ([]*domain.Codeset, error)
 	GetRepository(org, name string) (*domain.Codeset, error)
 	DeleteRepository(org, name string) error
+	GetProjects() ([]*domain.Project, error)
+	GetProject(org string) (*domain.Project, error)
+	DeleteProject(org string) error
 }
 
 // GitCodesetStore describes a stucture that accesses codeset store implemented in git

--- a/pkg/core/codeset_store.go
+++ b/pkg/core/codeset_store.go
@@ -19,6 +19,7 @@ type GitAdmin interface {
 	GetProjects() ([]*domain.Project, error)
 	GetProject(org string) (*domain.Project, error)
 	DeleteProject(org string) error
+	CreateProject(string, string, bool) (*domain.Project, error)
 }
 
 // GitCodesetStore describes a stucture that accesses codeset store implemented in git

--- a/pkg/core/gitea/client_test.go
+++ b/pkg/core/gitea/client_test.go
@@ -69,6 +69,9 @@ func (tc testGiteaClient) GetUserInfo(string) (*gitea.User, *gitea.Response, err
 func (tc testGiteaClient) AdminCreateUser(gitea.CreateUserOption) (*gitea.User, *gitea.Response, error) {
 	return nil, nil, nil
 }
+func (tc testGiteaClient) AdminDeleteUser(user string) (*gitea.Response, error) {
+	return nil, nil
+}
 func (tc testGiteaClient) ListOrgTeams(string, gitea.ListTeamsOptions) ([]*gitea.Team, *gitea.Response, error) {
 	// return default team for any org
 	teams := []*gitea.Team{{Name: "Owners", ID: 42}}
@@ -77,6 +80,9 @@ func (tc testGiteaClient) ListOrgTeams(string, gitea.ListTeamsOptions) ([]*gitea
 func (tc testGiteaClient) AddTeamMember(id int64, username string) (*gitea.Response, error) {
 	tc.testStore.teams[id] = append(tc.testStore.teams[id], username)
 	return nil, nil
+}
+func (tc testGiteaClient) DeleteOrgMembership(org, user string) (*gitea.Response, error) {
+	return &gitea.Response{Response: &httpResp200}, nil
 }
 
 func (tc testGiteaClient) ListTeamMembers(id int64, opts gitea.ListTeamMembersOptions) ([]*gitea.User, *gitea.Response, error) {
@@ -107,6 +113,11 @@ func (tc testGiteaClient) ListOrgRepos(org string, opt gitea.ListOrgReposOptions
 	return repos, nil, nil
 }
 
+func (tc testGiteaClient) ListUserOrgs(user string, opt gitea.ListOrgsOptions) ([]*gitea.Organization, *gitea.Response, error) {
+	userOrgs := make([]*gitea.Organization, 0)
+	return userOrgs, nil, nil
+}
+
 func (tc testGiteaClient) CreateRepoHook(string, string, gitea.CreateHookOption) (*gitea.Hook, *gitea.Response, error) {
 	return &gitea.Hook{ID: int64(1)}, nil, nil
 }
@@ -127,6 +138,10 @@ func (tc testGiteaClient) ListMyOrgs(gitea.ListOrgsOptions) ([]*gitea.Organizati
 
 func (tc testGiteaClient) DeleteRepo(owner, repo string) (*gitea.Response, error) {
 	delete(tc.testStore.projects2repos[owner], repo)
+	return nil, nil
+}
+
+func (tc testGiteaClient) DeleteOrg(orgname string) (*gitea.Response, error) {
 	return nil, nil
 }
 

--- a/pkg/core/gitea/client_test.go
+++ b/pkg/core/gitea/client_test.go
@@ -78,6 +78,12 @@ func (tc testGiteaClient) AddTeamMember(id int64, username string) (*gitea.Respo
 	tc.testStore.teams[id] = append(tc.testStore.teams[id], username)
 	return nil, nil
 }
+
+func (tc testGiteaClient) ListTeamMembers(id int64, opts gitea.ListTeamMembersOptions) ([]*gitea.User, *gitea.Response, error) {
+	users := make([]*gitea.User, 0)
+	return users, &gitea.Response{Response: &httpResp200}, nil
+}
+
 func (tc testGiteaClient) GetRepo(owner, reponame string) (*gitea.Repository, *gitea.Response, error) {
 	if repo, ok := tc.testStore.projects2repos[owner][reponame]; ok {
 		return &repo, &gitea.Response{Response: &httpResp200}, nil

--- a/pkg/core/project_store.go
+++ b/pkg/core/project_store.go
@@ -29,6 +29,15 @@ func (cs *GitProjectStore) Find(ctx context.Context, project string) (*domain.Pr
 	return result, nil
 }
 
+// Create creates a new project
+func (cs *GitProjectStore) Create(ctx context.Context, name, desc string) (*domain.Project, error) {
+	result, err := cs.gitAdmin.CreateProject(name, desc, false)
+	if err != nil {
+		return nil, errors.Wrap(err, "Creating Project failed")
+	}
+	return result, nil
+}
+
 // GetAll returns all projects matching given project and label
 func (cs *GitProjectStore) GetAll(ctx context.Context) ([]*domain.Project, error) {
 	result, err := cs.gitAdmin.GetProjects()

--- a/pkg/core/project_store.go
+++ b/pkg/core/project_store.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/fuseml/fuseml-core/pkg/domain"
+)
+
+// GitProjectStore describes a stucture that accesses project store implemented in git
+type GitProjectStore struct {
+	gitAdmin GitAdmin
+}
+
+// NewGitProjectStore returns project store instance
+func NewGitProjectStore(gitAdmin GitAdmin) *GitProjectStore {
+	return &GitProjectStore{
+		gitAdmin: gitAdmin,
+	}
+}
+
+// Find returns a project identified by project and name
+func (cs *GitProjectStore) Find(ctx context.Context, project string) (*domain.Project, error) {
+	result, err := cs.gitAdmin.GetProject(project)
+	if err != nil {
+		return nil, errors.Wrap(err, "Fetching Project failed")
+	}
+	return result, nil
+}
+
+// GetAll returns all projects matching given project and label
+func (cs *GitProjectStore) GetAll(ctx context.Context) ([]*domain.Project, error) {
+	result, err := cs.gitAdmin.GetProjects()
+	if err != nil {
+		return nil, errors.Wrap(err, "Fetching Projects failed")
+	}
+	return result, nil
+}
+
+// Delete removes a project identified by project and name
+func (cs *GitProjectStore) Delete(ctx context.Context, project string) error {
+	err := cs.gitAdmin.DeleteProject(project)
+	if err != nil {
+		return errors.Wrap(err, "Deleting Project failed")
+	}
+	return nil
+}

--- a/pkg/domain/project.go
+++ b/pkg/domain/project.go
@@ -1,0 +1,28 @@
+package domain
+
+import (
+	"context"
+)
+
+// Project represents a project artifact
+type Project struct {
+	// The name of the Project
+	Name string
+	// Project description
+	Description string
+	// Users assigned to the project
+	Users []*User
+}
+
+// User represents user assigned to the project
+type User struct {
+	Name  string
+	Email string
+}
+
+// ProjectStore is an inteface to project stores
+type ProjectStore interface {
+	Find(ctx context.Context, name string) (*Project, error)
+	GetAll(ctx context.Context) ([]*Project, error)
+	Delete(ctx context.Context, name string) error
+}

--- a/pkg/domain/project.go
+++ b/pkg/domain/project.go
@@ -25,4 +25,5 @@ type ProjectStore interface {
 	Find(ctx context.Context, name string) (*Project, error)
 	GetAll(ctx context.Context) ([]*Project, error)
 	Delete(ctx context.Context, name string) error
+	Create(ctx context.Context, name, desc string) (*Project, error)
 }

--- a/pkg/svc/project.go
+++ b/pkg/svc/project.go
@@ -57,6 +57,18 @@ func (s *projectsrvc) Get(ctx context.Context, p *project.GetPayload) (res *proj
 	return projectDomainToRest(c), nil
 }
 
+func (s *projectsrvc) Create(ctx context.Context, p *project.CreatePayload) (res *project.Project, err error) {
+	s.logger.Print("project.create")
+	c, err := s.store.Create(ctx, p.Name, p.Description)
+	if err != nil {
+		if err.Error() == "Project with that name already exists" {
+			return nil, project.MakeConflict(err)
+		}
+		return nil, err
+	}
+	return projectDomainToRest(c), nil
+}
+
 func (s *projectsrvc) Delete(ctx context.Context, p *project.DeletePayload) error {
 	s.logger.Print("project.delete")
 	return s.store.Delete(ctx, p.Name)

--- a/pkg/svc/project.go
+++ b/pkg/svc/project.go
@@ -1,0 +1,63 @@
+package svc
+
+import (
+	"context"
+	"log"
+
+	"github.com/fuseml/fuseml-core/gen/project"
+	"github.com/fuseml/fuseml-core/pkg/domain"
+)
+
+// project service implementation.
+type projectsrvc struct {
+	logger *log.Logger
+	store  domain.ProjectStore
+}
+
+// NewProjectService returns the project service implementation.
+func NewProjectService(logger *log.Logger, store domain.ProjectStore) project.Service {
+	return &projectsrvc{logger, store}
+}
+
+func projectDomainToRest(p *domain.Project) (res *project.Project) {
+	res = &project.Project{
+		Name:        p.Name,
+		Description: p.Description,
+	}
+
+	for _, u := range p.Users {
+		res.Users = append(res.Users,
+			&project.User{
+				Name:  u.Name,
+				Email: u.Email,
+			},
+		)
+	}
+	return
+}
+
+// Retrieve information about projects registered in FuseML.
+func (s *projectsrvc) List(ctx context.Context) (res []*project.Project, err error) {
+	s.logger.Print("project.list")
+	items, err := s.store.GetAll(ctx)
+	res = make([]*project.Project, 0, len(items))
+	for _, c := range items {
+		res = append(res, projectDomainToRest(c))
+	}
+	return res, err
+}
+
+// Retrieve an Project from FuseML.
+func (s *projectsrvc) Get(ctx context.Context, p *project.GetPayload) (res *project.Project, err error) {
+	s.logger.Print("project.get")
+	c, err := s.store.Find(ctx, p.Name)
+	if err != nil {
+		return nil, project.MakeBadRequest(err)
+	}
+	return projectDomainToRest(c), nil
+}
+
+func (s *projectsrvc) Delete(ctx context.Context, p *project.DeletePayload) error {
+	s.logger.Print("project.delete")
+	return s.store.Delete(ctx, p.Name)
+}


### PR DESCRIPTION
When CurrentProject is set in .fuseml/config.yaml, commands normally requiring "--project" option will use CurrentProject when "--project" is not provided.


implementation of https://github.com/fuseml/fuseml/issues/118


Example of `.fuseml/config.yaml` (note that it's not case sensitive):

```
currentcodeset: mlflow-02
currentproject: mlflow-project-02
url: http://localhost:8000
currentuser: fuseml-mlflow-project-02
currentpassword: newpassword
```

It's just one level for now, we can make it more structured if we find it useful.

The priorities go like: CLI option > env variable > config file under current directory > config file under $HOME 