### PR TITLE
workflow: Add workflow manager and some improvements

### DIFF
--- a/design/workflow.go
+++ b/design/workflow.go
@@ -14,11 +14,8 @@ var _ = Service("workflow", func() {
 				Example("workflowA")
 			})
 		})
-		Result(ArrayOf(Workflow), "Return all workflows matching the query.")
 
-		Error("NotFound", func() {
-			Description("If the workflow is not found, should return 404 Not Found.")
-		})
+		Result(ArrayOf(Workflow), "Return all workflows matching the query.")
 
 		HTTP(func() {
 			GET("/workflows")
@@ -26,12 +23,10 @@ var _ = Service("workflow", func() {
 				Example("workflowA")
 			})
 			Response(StatusOK)
-			Response("NotFound", StatusNotFound)
 		})
 
 		GRPC(func() {
 			Response(CodeOK)
-			Response("NotFound", CodeNotFound)
 		})
 
 	})

--- a/pkg/core/manager/workflow.go
+++ b/pkg/core/manager/workflow.go
@@ -116,7 +116,22 @@ func (mgr *workflowManager) ListAssignments(ctx context.Context, name *string) (
 }
 
 func (mgr *workflowManager) ListRuns(ctx context.Context, filter *domain.WorkflowRunFilter) ([]*workflow.WorkflowRun, error) {
-	return nil, nil
+	workflowRuns := []*workflow.WorkflowRun{}
+	var wfName *string
+	if filter != nil {
+		wfName = filter.WorkflowName
+	}
+	workflows := mgr.workflowStore.GetWorkflows(ctx, wfName)
+
+	for _, workflow := range workflows {
+		runs, err := mgr.workflowBackend.ListWorkflowRuns(ctx, workflow, filter)
+		if err != nil {
+			return nil, err
+		}
+		workflowRuns = append(workflowRuns, runs...)
+	}
+
+	return workflowRuns, nil
 }
 
 func newWorkflowAssignment(workflowName string, codesets []*domain.AssignedCodeset, listener *domain.WorkflowListener) *workflow.WorkflowAssignment {

--- a/pkg/core/manager/workflow.go
+++ b/pkg/core/manager/workflow.go
@@ -20,7 +20,7 @@ func NewWorkflowManager(workflowBackend domain.WorkflowBackend, workflowStore do
 }
 
 func (mgr *workflowManager) List(ctx context.Context, name *string) []*workflow.Workflow {
-	return nil
+	return mgr.workflowStore.GetWorkflows(ctx, name)
 }
 
 func (mgr *workflowManager) Create(ctx context.Context, wf *workflow.Workflow) (*workflow.Workflow, error) {

--- a/pkg/core/manager/workflow.go
+++ b/pkg/core/manager/workflow.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"time"
 
 	"github.com/fuseml/fuseml-core/gen/workflow"
 	"github.com/fuseml/fuseml-core/pkg/domain"
@@ -23,7 +24,13 @@ func (mgr *workflowManager) List(ctx context.Context, name *string) []*workflow.
 }
 
 func (mgr *workflowManager) Create(ctx context.Context, wf *workflow.Workflow) (*workflow.Workflow, error) {
-	return nil, nil
+	workflowDateCreated := time.Now().Format(time.RFC3339)
+	wf.Created = &workflowDateCreated
+	err := mgr.workflowBackend.CreateWorkflow(ctx, wf)
+	if err != nil {
+		return nil, err
+	}
+	return mgr.workflowStore.AddWorkflow(ctx, wf)
 }
 
 func (mgr *workflowManager) Get(ctx context.Context, name string) (*workflow.Workflow, error) {

--- a/pkg/core/manager/workflow.go
+++ b/pkg/core/manager/workflow.go
@@ -19,6 +19,7 @@ type workflowManager struct {
 }
 
 // NewWorkflowManager initializes a Workflow Manager
+// FIXME: instead of CodesetStore, receive a CodesetManager
 func NewWorkflowManager(workflowBackend domain.WorkflowBackend, workflowStore domain.WorkflowStore, codesetStore domain.CodesetStore) domain.WorkflowManager {
 	return &workflowManager{workflowBackend, workflowStore, codesetStore}
 }

--- a/pkg/core/manager/workflow.go
+++ b/pkg/core/manager/workflow.go
@@ -1,0 +1,51 @@
+package manager
+
+import (
+	"context"
+
+	"github.com/fuseml/fuseml-core/gen/workflow"
+	"github.com/fuseml/fuseml-core/pkg/domain"
+)
+
+type workflowManager struct {
+	workflowBackend domain.WorkflowBackend
+	workflowStore   domain.WorkflowStore
+	codesetStore    domain.CodesetStore
+}
+
+// NewWorkflowManager initializes a Workflow Manager
+func NewWorkflowManager(workflowBackend domain.WorkflowBackend, workflowStore domain.WorkflowStore, codesetStore domain.CodesetStore) domain.WorkflowManager {
+	return &workflowManager{workflowBackend, workflowStore, codesetStore}
+}
+
+func (mgr *workflowManager) List(ctx context.Context, name *string) []*workflow.Workflow {
+	return nil
+}
+
+func (mgr *workflowManager) Create(ctx context.Context, wf *workflow.Workflow) (*workflow.Workflow, error) {
+	return nil, nil
+}
+
+func (mgr *workflowManager) Get(ctx context.Context, name string) (*workflow.Workflow, error) {
+	return nil, nil
+}
+
+func (mgr *workflowManager) Delete(ctx context.Context, name string) error {
+	return nil
+}
+
+func (mgr *workflowManager) AssignToCodeset(ctx context.Context, name, codesetProject, codesetName string) (wfListener *domain.WorkflowListener, webhookID *int64, err error) {
+	return
+}
+
+func (mgr *workflowManager) UnassignFromCodeset(ctx context.Context, name, codesetProject, codesetName string) (err error) {
+	return
+}
+
+func (mgr *workflowManager) ListAssignments(ctx context.Context, name *string) ([]*workflow.WorkflowAssignment, error) {
+	return nil, nil
+}
+
+func (mgr *workflowManager) ListRuns(ctx context.Context, filter *domain.WorkflowRunFilter) ([]*workflow.WorkflowRun, error) {
+	return nil, nil
+}

--- a/pkg/core/manager/workflow.go
+++ b/pkg/core/manager/workflow.go
@@ -34,7 +34,7 @@ func (mgr *workflowManager) Create(ctx context.Context, wf *workflow.Workflow) (
 }
 
 func (mgr *workflowManager) Get(ctx context.Context, name string) (*workflow.Workflow, error) {
-	return nil, nil
+	return mgr.workflowStore.GetWorkflow(ctx, name)
 }
 
 func (mgr *workflowManager) Delete(ctx context.Context, name string) error {

--- a/pkg/core/manager/workflow_test.go
+++ b/pkg/core/manager/workflow_test.go
@@ -1,0 +1,179 @@
+package manager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fuseml/fuseml-core/gen/workflow"
+	"github.com/fuseml/fuseml-core/pkg/core"
+	"github.com/fuseml/fuseml-core/pkg/domain"
+)
+
+const errCodesetNotFound = codesetErr("codeset not found")
+
+var (
+	// workflowBackend stores WorkflowListener and WorkflowRuns for a workflow created by fakeWorkflowBackend
+	workflowBackend domain.WorkflowBackend
+
+	// workflowStore stores Workflow and Assignments
+	workflowStore domain.WorkflowStore
+
+	// codesetStore stores codesets that are created when initializing fakeWorkflowManager
+	// The following codesets are created when calling newFakeWorkflowManager:
+	codesetStore domain.CodesetStore
+
+	// workflowRunStatuses are the possible Status for a WorkflowRun. The status of a WorkflowRun is set
+	// accordingly to its order, cycling between the workflowRunStatuses. E.g. run0: Succeeded, run1: Failed,
+	// run2: Succeeded, ...
+	workflowRunStatuses = []string{"Succeeded", "Failed"}
+)
+
+type codesetErr string
+
+func (e codesetErr) Error() string {
+	return string(e)
+}
+
+func TestCreate(t *testing.T) {
+
+}
+
+func TestList(t *testing.T) {
+
+}
+
+func TestGet(t *testing.T) {
+
+}
+
+func TestDelete(t *testing.T) {
+
+}
+
+func TestAssignToCodeset(t *testing.T) {
+
+}
+
+func TestUnassignFromCodeset(t *testing.T) {
+
+}
+
+func TestListAssignments(t *testing.T) {
+
+}
+
+func TestListRuns(t *testing.T) {
+
+}
+
+func newFakeWorkflowManager(t *testing.T) domain.WorkflowManager {
+	t.Helper()
+
+	workflowStore = core.NewWorkflowStore()
+	workflowBackend = &fakeWorkflowBackend{t, make(map[string]*fakeStorableWorkflow)}
+
+	codesetStore = &fakeCodesetStore{t, make(map[codesetID]fakeStorableCodeset)}
+	return NewWorkflowManager(workflowBackend, workflowStore, codesetStore)
+}
+
+type fakeStorableWorkflow struct {
+	listener *domain.WorkflowListener
+	runs     []*workflow.WorkflowRun
+}
+
+type fakeWorkflowBackend struct {
+	t         *testing.T
+	workflows map[string]*fakeStorableWorkflow
+}
+
+func (b *fakeWorkflowBackend) CreateWorkflow(ctx context.Context, w *workflow.Workflow) error {
+	b.t.Helper()
+
+	return nil
+}
+
+func (b *fakeWorkflowBackend) DeleteWorkflow(ctx context.Context, workflowName string) error {
+	b.t.Helper()
+
+	return nil
+}
+
+func (b *fakeWorkflowBackend) CreateWorkflowRun(ctx context.Context, workflowName string, codeset *domain.Codeset) error {
+	b.t.Helper()
+
+	return nil
+}
+
+func (b *fakeWorkflowBackend) ListWorkflowRuns(ctx context.Context, wf *workflow.Workflow, filter *domain.WorkflowRunFilter) ([]*workflow.WorkflowRun, error) {
+	b.t.Helper()
+
+	return nil, nil
+}
+
+func (b *fakeWorkflowBackend) CreateWorkflowListener(ctx context.Context, workflowName string, timeout time.Duration) (*domain.WorkflowListener, error) {
+	b.t.Helper()
+
+	return nil, nil
+}
+
+func (b *fakeWorkflowBackend) DeleteWorkflowListener(ctx context.Context, workflowName string) error {
+	b.t.Helper()
+
+	return nil
+}
+
+func (b *fakeWorkflowBackend) GetWorkflowListener(ctx context.Context, workflowName string) (*domain.WorkflowListener, error) {
+	b.t.Helper()
+
+	return nil, nil
+}
+
+type codesetID struct {
+	name    string
+	project string
+}
+
+type fakeStorableCodeset struct {
+	codeset  *domain.Codeset
+	webhooks map[int64]string
+}
+
+type fakeCodesetStore struct {
+	t     *testing.T
+	store map[codesetID]fakeStorableCodeset
+}
+
+func (fcs *fakeCodesetStore) Add(ctx context.Context, c *domain.Codeset) (*domain.Codeset, *string, *string, error) {
+	fcs.t.Helper()
+
+	return nil, nil, nil, nil
+}
+
+func (fcs *fakeCodesetStore) CreateWebhook(ctx context.Context, c *domain.Codeset, url string) (*int64, error) {
+	fcs.t.Helper()
+
+	return nil, nil
+}
+
+func (fcs *fakeCodesetStore) DeleteWebhook(ctx context.Context, c *domain.Codeset, id *int64) error {
+	fcs.t.Helper()
+
+	return nil
+}
+
+func (fcs *fakeCodesetStore) Delete(ctx context.Context, project, name string) error {
+	return nil
+}
+
+func (fcs *fakeCodesetStore) Find(ctx context.Context, project, name string) (*domain.Codeset, error) {
+	fcs.t.Helper()
+
+	return nil, nil
+}
+
+func (fcs *fakeCodesetStore) GetAll(ctx context.Context, project, label *string) (res []*domain.Codeset, err error) {
+	fcs.t.Helper()
+
+	return nil, nil
+}

--- a/pkg/core/manager/workflow_test.go
+++ b/pkg/core/manager/workflow_test.go
@@ -130,7 +130,24 @@ func TestList(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
+	t.Run("get", func(t *testing.T) {
+		mgr := newFakeWorkflowManager(t)
+		want, err := mgr.Create(context.Background(), &workflow.Workflow{Name: "wf"})
+		assertError(t, err, nil)
 
+		got, err := mgr.Get(context.Background(), want.Name)
+		assertError(t, err, nil)
+
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("Unexpected Workflow: %s", diff.PrintWantGot(d))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mgr := newFakeWorkflowManager(t)
+		_, err := mgr.Get(context.Background(), "wf")
+		assertError(t, err, domain.ErrWorkflowNotFound)
+	})
 }
 
 func TestDelete(t *testing.T) {

--- a/pkg/core/manager/workflow_test.go
+++ b/pkg/core/manager/workflow_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -155,7 +156,66 @@ func TestDelete(t *testing.T) {
 }
 
 func TestAssignToCodeset(t *testing.T) {
+	t.Run("assign", func(t *testing.T) {
+		mgr := newFakeWorkflowManager(t)
 
+		wf, err := mgr.Create(context.Background(), &workflow.Workflow{Name: "wf"})
+		assertError(t, err, nil)
+
+		codesets, _ := codesetStore.GetAll(context.TODO(), nil, nil)
+		wantListener, webhookID, err := mgr.AssignToCodeset(context.Background(), wf.Name, codesets[0].Project, codesets[0].Name)
+		assertError(t, err, nil)
+
+		got := workflowStore.GetAssignments(context.TODO(), &wf.Name)
+		want := map[string][]*domain.AssignedCodeset{wf.Name: {{Codeset: codesets[0], WebhookID: webhookID}}}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("Unexpected Assignment: %s", diff.PrintWantGot(d))
+		}
+
+		gotListener, err := workflowBackend.GetWorkflowListener(context.TODO(), wf.Name)
+		assertError(t, err, nil)
+		if d := cmp.Diff(wantListener, gotListener); d != "" {
+			t.Errorf("Unexpected Listener: %s", diff.PrintWantGot(d))
+		}
+	})
+
+	t.Run("workflow not found", func(t *testing.T) {
+		mgr := newFakeWorkflowManager(t)
+
+		wfName := "unknownWf"
+		codesets, _ := codesetStore.GetAll(context.TODO(), nil, nil)
+		_, _, got := mgr.AssignToCodeset(context.Background(), wfName, codesets[0].Project, codesets[0].Name)
+		assertError(t, got, domain.ErrWorkflowNotFound)
+
+		gotAss := workflowStore.GetAssignments(context.TODO(), nil)
+		wantAss := map[string][]*domain.AssignedCodeset{}
+		if d := cmp.Diff(wantAss, gotAss); d != "" {
+			t.Errorf("Unexpected Assignment: %s", diff.PrintWantGot(d))
+		}
+
+		_, err := workflowBackend.GetWorkflowListener(context.TODO(), wfName)
+		assertStrings(t, err.Error(), "listener not found")
+
+	})
+
+	t.Run("codeset not found", func(t *testing.T) {
+		mgr := newFakeWorkflowManager(t)
+
+		wf, err := mgr.Create(context.Background(), &workflow.Workflow{Name: "wf"})
+		assertError(t, err, nil)
+
+		_, _, got := mgr.AssignToCodeset(context.Background(), wf.Name, "unknownProj", "unknownCs")
+		assertError(t, got, errCodesetNotFound)
+
+		gotAss := workflowStore.GetAssignments(context.TODO(), nil)
+		wantAss := map[string][]*domain.AssignedCodeset{}
+		if d := cmp.Diff(wantAss, gotAss); d != "" {
+			t.Errorf("Unexpected Assignment: %s", diff.PrintWantGot(d))
+		}
+
+		_, err = workflowBackend.GetWorkflowListener(context.TODO(), wf.Name)
+		assertStrings(t, err.Error(), "listener not found")
+	})
 }
 
 func TestUnassignFromCodeset(t *testing.T) {
@@ -175,6 +235,14 @@ func assertError(t testing.TB, got, want error) {
 
 	if got != want {
 		t.Errorf("got error %q want %q", got, want)
+	}
+}
+
+func assertStrings(t testing.TB, got, want string) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
 	}
 }
 
@@ -236,6 +304,28 @@ func (b *fakeWorkflowBackend) DeleteWorkflow(ctx context.Context, workflowName s
 func (b *fakeWorkflowBackend) CreateWorkflowRun(ctx context.Context, workflowName string, codeset *domain.Codeset) error {
 	b.t.Helper()
 
+	if _, exists := b.workflows[workflowName]; !exists {
+		return fmt.Errorf("workflow not found")
+	}
+
+	runs := b.workflows[workflowName].runs
+	name := fmt.Sprintf("%s-run%d", workflowName, len(runs))
+	codesetInputName := "codeset-name"
+	codesetInputType := "codeset"
+	codesetInputValue := fmt.Sprintf("%s/%s", codeset.Project, codeset.Name)
+	stringInputName := "predictor"
+	stringInputType := "string"
+	stringInputValue := "sklearn"
+
+	run := &workflow.WorkflowRun{
+		Name:        &name,
+		WorkflowRef: &workflowName,
+		Inputs: []*workflow.WorkflowRunInput{
+			{Input: &workflow.WorkflowInput{Name: &codesetInputName, Type: &codesetInputType}, Value: &codesetInputValue},
+			{Input: &workflow.WorkflowInput{Name: &stringInputName, Type: &stringInputType}, Value: &stringInputValue}},
+		Status: &workflowRunStatuses[len(runs)%len(workflowRunStatuses)]}
+
+	b.workflows[workflowName].runs = append(b.workflows[workflowName].runs, run)
 	return nil
 }
 
@@ -248,7 +338,13 @@ func (b *fakeWorkflowBackend) ListWorkflowRuns(ctx context.Context, wf *workflow
 func (b *fakeWorkflowBackend) CreateWorkflowListener(ctx context.Context, workflowName string, timeout time.Duration) (*domain.WorkflowListener, error) {
 	b.t.Helper()
 
-	return nil, nil
+	listener := b.workflows[workflowName].listener
+	if listener == nil {
+		listener = &domain.WorkflowListener{Name: workflowName, Available: true, URL: fmt.Sprintf("http://%s.listener.test", workflowName),
+			DashboardURL: fmt.Sprintf("http://dashboard.test/%s", workflowName)}
+		b.workflows[workflowName].listener = listener
+	}
+	return listener, nil
 }
 
 func (b *fakeWorkflowBackend) DeleteWorkflowListener(ctx context.Context, workflowName string) error {
@@ -260,7 +356,12 @@ func (b *fakeWorkflowBackend) DeleteWorkflowListener(ctx context.Context, workfl
 func (b *fakeWorkflowBackend) GetWorkflowListener(ctx context.Context, workflowName string) (*domain.WorkflowListener, error) {
 	b.t.Helper()
 
-	return nil, nil
+	if wf, exists := b.workflows[workflowName]; exists {
+		if wf.listener != nil {
+			return wf.listener, nil
+		}
+	}
+	return nil, fmt.Errorf("listener not found")
 }
 
 type codesetID struct {
@@ -288,7 +389,9 @@ func (fcs *fakeCodesetStore) Add(ctx context.Context, c *domain.Codeset) (*domai
 func (fcs *fakeCodesetStore) CreateWebhook(ctx context.Context, c *domain.Codeset, url string) (*int64, error) {
 	fcs.t.Helper()
 
-	return nil, nil
+	id := rand.Int63()
+	fcs.store[codesetID{c.Name, c.Project}].webhooks[id] = url
+	return &id, nil
 }
 
 func (fcs *fakeCodesetStore) DeleteWebhook(ctx context.Context, c *domain.Codeset, id *int64) error {
@@ -304,7 +407,10 @@ func (fcs *fakeCodesetStore) Delete(ctx context.Context, project, name string) e
 func (fcs *fakeCodesetStore) Find(ctx context.Context, project, name string) (*domain.Codeset, error) {
 	fcs.t.Helper()
 
-	return nil, nil
+	if sc, exists := fcs.store[codesetID{name, project}]; exists {
+		return sc.codeset, nil
+	}
+	return nil, errCodesetNotFound
 }
 
 func (fcs *fakeCodesetStore) GetAll(ctx context.Context, project, label *string) (res []*domain.Codeset, err error) {

--- a/pkg/core/manager/workflow_test.go
+++ b/pkg/core/manager/workflow_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fuseml/fuseml-core/gen/workflow"
-	"github.com/fuseml/fuseml-core/pkg/core"
-	"github.com/fuseml/fuseml-core/pkg/domain"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/test/diff"
+
+	"github.com/fuseml/fuseml-core/gen/workflow"
+	"github.com/fuseml/fuseml-core/pkg/core"
+	"github.com/fuseml/fuseml-core/pkg/domain"
 )
 
 const errCodesetNotFound = codesetErr("codeset not found")
@@ -76,7 +77,6 @@ func TestCreate(t *testing.T) {
 			t.Errorf("Unexpected Workflow: %s", diff.PrintWantGot(d))
 		}
 	})
-
 }
 
 func TestList(t *testing.T) {

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -47,12 +47,13 @@ type WorkflowBackendErr string
 type WorkflowBackend struct {
 	dashboardURL  string
 	namespace     string
+	logger        *log.Logger
 	tektonClients *clients
 }
 
 // NewWorkflowBackend initializes Tekton backend
-func NewWorkflowBackend(namespace string) (*WorkflowBackend, error) {
-	dashbboardURL, exists := os.LookupEnv("TEKTON_DASHBOARD_URL")
+func NewWorkflowBackend(logger *log.Logger, namespace string) (*WorkflowBackend, error) {
+	dashboardURL, exists := os.LookupEnv("TEKTON_DASHBOARD_URL")
 	if !exists {
 		return nil, errDashboardURLMissing
 	}
@@ -60,13 +61,13 @@ func NewWorkflowBackend(namespace string) (*WorkflowBackend, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error initializing tekton workflow backend: %w", err)
 	}
-	return &WorkflowBackend{strings.TrimSuffix(dashbboardURL, "/"), namespace, clients}, nil
+	return &WorkflowBackend{strings.TrimSuffix(dashboardURL, "/"), namespace, logger, clients}, nil
 }
 
 // CreateWorkflow receives a FuseML workflow and creates a Tekton pipeline from it
-func (w *WorkflowBackend) CreateWorkflow(ctx context.Context, logger *log.Logger, workflow *workflow.Workflow) error {
+func (w *WorkflowBackend) CreateWorkflow(ctx context.Context, workflow *workflow.Workflow) error {
 	pipeline := generatePipeline(*workflow, w.namespace)
-	logger.Printf("Creating tekton pipeline for workflow: %s...", workflow.Name)
+	w.logger.Printf("Creating tekton pipeline for workflow: %s...", workflow.Name)
 	_, err := w.tektonClients.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{})
 	if err != nil {
 		if k8serr.IsAlreadyExists(err) {
@@ -79,20 +80,20 @@ func (w *WorkflowBackend) CreateWorkflow(ctx context.Context, logger *log.Logger
 }
 
 // DeleteWorkflow deletes a tekton pipeline with the specified name
-func (w *WorkflowBackend) DeleteWorkflow(ctx context.Context, logger *log.Logger, name string) error {
-	logger.Printf("Deleting tekton pipeline: %s...", name)
+func (w *WorkflowBackend) DeleteWorkflow(ctx context.Context, name string) error {
+	w.logger.Printf("Deleting tekton pipeline: %s...", name)
 	err := w.tektonClients.PipelineClient.Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if !k8serr.IsNotFound(err) {
 			return fmt.Errorf("error deleting tekton pipeline %q: %w", name, err)
 		}
-		logger.Printf("Tekton pipeline %q not found, skipping delete...", name)
+		w.logger.Printf("Tekton pipeline %q not found, skipping delete...", name)
 	}
 	return nil
 }
 
 // CreateWorkflowRun creates a PipelineRun with its default values for the specified workflow and codeset
-func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, logger *log.Logger, workflowName string, codeset *domain.Codeset) error {
+func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, workflowName string, codeset *domain.Codeset) error {
 	pipeline, err := w.tektonClients.PipelineClient.Get(ctx, workflowName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting tekton pipeline %q: %w", workflowName, err)
@@ -103,7 +104,7 @@ func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, logger *log.Log
 		return fmt.Errorf("error generating tekton pipeline run for workflow %q: %w", workflowName, err)
 	}
 
-	logger.Printf("Creating tekton pipeline run for workflow: %s...", workflowName)
+	w.logger.Printf("Creating tekton pipeline run for workflow: %s...", workflowName)
 	_, err = w.tektonClients.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("error creating tekton pipeline run %q: %w", pipelineRun.Name, err)
@@ -139,7 +140,7 @@ func (w *WorkflowBackend) ListWorkflowRuns(ctx context.Context, wf workflow.Work
 }
 
 // CreateWorkflowListener creates tekton resources required to have a listener ready for triggering the pipeline
-func (w *WorkflowBackend) CreateWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string, timeout time.Duration) (*domain.WorkflowListener, error) {
+func (w *WorkflowBackend) CreateWorkflowListener(ctx context.Context, workflowName string, timeout time.Duration) (*domain.WorkflowListener, error) {
 	pipeline, err := w.tektonClients.PipelineClient.Get(ctx, workflowName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting tekton pipeline %q: %w", workflowName, err)
@@ -151,13 +152,13 @@ func (w *WorkflowBackend) CreateWorkflowListener(ctx context.Context, logger *lo
 		if !k8serr.IsNotFound(err) {
 			return nil, fmt.Errorf("error getting tekton trigger template %q: %w", workflowName, err)
 		}
-		logger.Printf("Creating tekton trigger template for workflow: %s...", workflowName)
+		w.logger.Printf("Creating tekton trigger template for workflow: %s...", workflowName)
 		var tt *v1alpha1.TriggerTemplate
 		tt, err = w.tektonClients.TriggerTemplateClient.Create(ctx, triggerTemplate, metav1.CreateOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("error creating tekton trigger template %q: %w", workflowName, err)
 		}
-		defer w.tektonDeleteIfError(ctx, logger, &err, tt)
+		defer w.tektonDeleteIfError(ctx, &err, tt)
 	}
 
 	triggerBinding := generateTriggerBinding(triggerTemplate)
@@ -166,13 +167,13 @@ func (w *WorkflowBackend) CreateWorkflowListener(ctx context.Context, logger *lo
 		if !k8serr.IsNotFound(err) {
 			return nil, fmt.Errorf("error getting tekton trigger binding %q: %w", workflowName, err)
 		}
-		logger.Printf("Creating tekton trigger binding for workflow: %s...", workflowName)
+		w.logger.Printf("Creating tekton trigger binding for workflow: %s...", workflowName)
 		var tb *v1alpha1.TriggerBinding
 		tb, err = w.tektonClients.TriggerBindingClient.Create(ctx, triggerBinding, metav1.CreateOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("error creating tekton trigger binding %q: %w", workflowName, err)
 		}
-		defer w.tektonDeleteIfError(ctx, logger, &err, tb)
+		defer w.tektonDeleteIfError(ctx, &err, tb)
 	}
 
 	eventListener := generateEventListener(triggerTemplate, triggerBinding)
@@ -182,12 +183,12 @@ func (w *WorkflowBackend) CreateWorkflowListener(ctx context.Context, logger *lo
 		if !k8serr.IsNotFound(err) {
 			return nil, fmt.Errorf("error getting tekton event listener %q: %w", workflowName, err)
 		}
-		logger.Printf("Creating tekton event listener for workflow: %s...", workflowName)
+		w.logger.Printf("Creating tekton event listener for workflow: %s...", workflowName)
 		el, err = w.tektonClients.EventListenerClient.Create(ctx, eventListener, metav1.CreateOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("error creating tekton event listener %q: %w", workflowName, err)
 		}
-		defer w.tektonDeleteIfError(ctx, logger, &err, el)
+		defer w.tektonDeleteIfError(ctx, &err, el)
 	}
 
 	url := fmt.Sprintf("http://el-%s.%s.svc.cluster.local:8080", workflowName, w.namespace)
@@ -209,32 +210,32 @@ func (w *WorkflowBackend) CreateWorkflowListener(ctx context.Context, logger *lo
 }
 
 // DeleteWorkflowListener deletes all tekton resources associated to the specified listener name
-func (w *WorkflowBackend) DeleteWorkflowListener(ctx context.Context, logger *log.Logger, name string) error {
-	logger.Printf("Deleting tekton event listener: %s...", name)
+func (w *WorkflowBackend) DeleteWorkflowListener(ctx context.Context, name string) error {
+	w.logger.Printf("Deleting tekton event listener: %s...", name)
 	err := w.tektonClients.EventListenerClient.Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if !k8serr.IsNotFound(err) {
 			return fmt.Errorf("error deleting tekton event listener %q: %w", name, err)
 		}
-		logger.Printf("Tekton event listener %q not found, skipping delete...", name)
+		w.logger.Printf("Tekton event listener %q not found, skipping delete...", name)
 	}
 
-	logger.Printf("Deleting tekton trigger binding: %s...", name)
+	w.logger.Printf("Deleting tekton trigger binding: %s...", name)
 	err = w.tektonClients.TriggerBindingClient.Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if !k8serr.IsNotFound(err) {
 			return fmt.Errorf("error deleting tekton trigger binding %q: %w", name, err)
 		}
-		logger.Printf("Tekton trigger binding %q not found, skipping delete...", name)
+		w.logger.Printf("Tekton trigger binding %q not found, skipping delete...", name)
 	}
 
-	logger.Printf("Deleting tekton trigger template: %s...", name)
+	w.logger.Printf("Deleting tekton trigger template: %s...", name)
 	err = w.tektonClients.TriggerTemplateClient.Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if !k8serr.IsNotFound(err) {
 			return fmt.Errorf("error deleting tekton trigger template %q: %w", name, err)
 		}
-		logger.Printf("Tekton trigger template %q not found, skipping delete...", name)
+		w.logger.Printf("Tekton trigger template %q not found, skipping delete...", name)
 	}
 	return nil
 }
@@ -659,17 +660,17 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
-func (w *WorkflowBackend) tektonDeleteIfError(ctx context.Context, log *log.Logger, err *error, tektonWorkload interface{}) {
+func (w *WorkflowBackend) tektonDeleteIfError(ctx context.Context, err *error, tektonWorkload interface{}) {
 	if *err != nil {
 		switch tw := tektonWorkload.(type) {
 		case *v1alpha1.TriggerTemplate:
-			log.Printf("Deleting TriggerTemplate: %s... (creating listener failed)", tw.Name)
+			w.logger.Printf("Deleting TriggerTemplate: %s... (creating listener failed)", tw.Name)
 			w.tektonClients.TriggerTemplateClient.Delete(ctx, tw.Name, metav1.DeleteOptions{})
 		case *v1alpha1.TriggerBinding:
-			log.Printf("Deleting TriggerBinding: %s... (creating listener failed)", tw.Name)
+			w.logger.Printf("Deleting TriggerBinding: %s... (creating listener failed)", tw.Name)
 			w.tektonClients.TriggerBindingClient.Delete(ctx, tw.Name, metav1.DeleteOptions{})
 		case *v1alpha1.EventListener:
-			log.Printf("Deleting EventListener: %s... (creating listener failed)", tw.Name)
+			w.logger.Printf("Deleting EventListener: %s... (creating listener failed)", tw.Name)
 			w.tektonClients.EventListenerClient.Delete(ctx, tw.Name, metav1.DeleteOptions{})
 		}
 	}

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -113,10 +113,10 @@ func (w *WorkflowBackend) CreateWorkflowRun(ctx context.Context, workflowName st
 }
 
 // ListWorkflowRuns returns a list of WorkflowRun for the given Workflow
-func (w *WorkflowBackend) ListWorkflowRuns(ctx context.Context, wf workflow.Workflow, filters domain.WorkflowRunFilter) ([]*workflow.WorkflowRun, error) {
+func (w *WorkflowBackend) ListWorkflowRuns(ctx context.Context, wf *workflow.Workflow, filter *domain.WorkflowRunFilter) ([]*workflow.WorkflowRun, error) {
 	labelSelector := fmt.Sprintf("%s=%s", LabelWorkflowRef, wf.Name)
-	if filters.ByLabel != nil && len(filters.ByLabel) > 0 {
-		labelSelector = fmt.Sprintf("%s,%s", labelSelector, strings.Join(filters.ByLabel, ","))
+	if filter.ByLabel != nil && len(filter.ByLabel) > 0 {
+		labelSelector = fmt.Sprintf("%s,%s", labelSelector, strings.Join(filter.ByLabel, ","))
 	}
 	runs, err := w.tektonClients.PipelineRunClient.List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
@@ -124,9 +124,9 @@ func (w *WorkflowBackend) ListWorkflowRuns(ctx context.Context, wf workflow.Work
 	}
 	workflowRuns := []*workflow.WorkflowRun{}
 
-	if filters.ByStatus != nil && len(filters.ByStatus) > 0 {
+	if filter.ByStatus != nil && len(filter.ByStatus) > 0 {
 		for _, run := range runs.Items {
-			if len(run.Status.Conditions) > 0 && contains(filters.ByStatus,
+			if len(run.Status.Conditions) > 0 && contains(filter.ByStatus,
 				pipelineReasonToWorkflowStatus(run.Status.Conditions[0].Reason)) {
 				workflowRuns = append(workflowRuns, w.toWorkflowRun(wf, run))
 			}
@@ -570,7 +570,7 @@ func getInputCodesetPath(inputs []*workflow.WorkflowStepInput) string {
 	return ""
 }
 
-func (w *WorkflowBackend) toWorkflowRun(wf workflow.Workflow, p v1beta1.PipelineRun) *workflow.WorkflowRun {
+func (w *WorkflowBackend) toWorkflowRun(wf *workflow.Workflow, p v1beta1.PipelineRun) *workflow.WorkflowRun {
 
 	wfr := workflow.WorkflowRun{
 		Name:        &p.ObjectMeta.Name,

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -25,23 +25,20 @@ import (
 )
 
 const (
-	errWorkflowExists      = WorkflowBackendErr("workflow already exists")
-	errDashboardURLMissing = WorkflowBackendErr("Value for Tekton Dashboard URL (TEKTON_DASHBOARD_URL) was not provided.")
+	errDashboardURLMissing = WorkflowBackendErr("value for Tekton Dashboard URL (TEKTON_DASHBOARD_URL) was not provided.")
 	errWaitListenerTimeout = WorkflowBackendErr("time out waiting for listener to become ready")
 )
+
+var globalEnvVars []EnvVar
+
+// WorkflowBackendErr are expected errors returned from the WorkflowBackend
+type WorkflowBackendErr string
 
 // EnvVar describes environment variable and its value that needs to be passed to tekton task
 type EnvVar struct {
 	name  string
 	value string
 }
-
-var (
-	globalEnvVars []EnvVar
-)
-
-// WorkflowBackendErr are expected errors returned from the WorkflowBackend
-type WorkflowBackendErr string
 
 // WorkflowBackend implements the FuseML WorkflowBackend interface for tekton
 type WorkflowBackend struct {
@@ -71,7 +68,7 @@ func (w *WorkflowBackend) CreateWorkflow(ctx context.Context, workflow *workflow
 	_, err := w.tektonClients.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{})
 	if err != nil {
 		if k8serr.IsAlreadyExists(err) {
-			return errWorkflowExists
+			return domain.ErrWorkflowExists
 		}
 		return fmt.Errorf("error creating tekton pipeline for workflow %q: %w", workflow.Name, err)
 	}

--- a/pkg/core/tekton/tekton_test.go
+++ b/pkg/core/tekton/tekton_test.go
@@ -207,7 +207,7 @@ func TestListWorkflowRuns(t *testing.T) {
 		}
 
 		filter := domain.WorkflowRunFilter{}
-		got, err := b.ListWorkflowRuns(ctx, w, filter)
+		got, err := b.ListWorkflowRuns(ctx, &w, &filter)
 		if err != nil {
 			t.Fatalf("Failed to list PipelineRun: %s", err)
 		}
@@ -252,9 +252,9 @@ func TestListWorkflowRuns(t *testing.T) {
 			codesets = append(codesets, cs)
 		}
 
-		filterNil := domain.WorkflowRunFilter{ByLabel: nil}
+		filterNil := domain.WorkflowRunFilter{}
 		want := wants
-		got, err := b.ListWorkflowRuns(ctx, w, filterNil)
+		got, err := b.ListWorkflowRuns(ctx, &w, &filterNil)
 		if err != nil {
 			t.Fatalf("Failed to list WorkflowRun: %s", err)
 		}
@@ -264,7 +264,7 @@ func TestListWorkflowRuns(t *testing.T) {
 
 		filterEmpty := domain.WorkflowRunFilter{ByLabel: []string{}}
 		want = wants
-		got, err = b.ListWorkflowRuns(ctx, w, filterEmpty)
+		got, err = b.ListWorkflowRuns(ctx, &w, &filterEmpty)
 		if err != nil {
 			t.Fatalf("Failed to list WorkflowRun: %s", err)
 		}
@@ -274,7 +274,7 @@ func TestListWorkflowRuns(t *testing.T) {
 
 		filterNoResult := domain.WorkflowRunFilter{ByLabel: []string{fmt.Sprintf("%s=%s", LabelCodesetName, "do-no-exist")}}
 		want = []*workflow.WorkflowRun{}
-		got, err = b.ListWorkflowRuns(ctx, w, filterNoResult)
+		got, err = b.ListWorkflowRuns(ctx, &w, &filterNoResult)
 		if err != nil {
 			t.Fatalf("Failed to list WorkflowRun: %s", err)
 		}
@@ -285,7 +285,7 @@ func TestListWorkflowRuns(t *testing.T) {
 		for i := 0; i < len(codesets); i++ {
 			filterCodesetName := domain.WorkflowRunFilter{ByLabel: []string{fmt.Sprintf("%s=%s", LabelCodesetName, codesets[i].Name)}}
 			want := []*workflow.WorkflowRun{wants[i]}
-			got, err := b.ListWorkflowRuns(ctx, w, filterCodesetName)
+			got, err := b.ListWorkflowRuns(ctx, &w, &filterCodesetName)
 			if err != nil {
 				t.Fatalf("Failed to list WorkflowRun: %s", err)
 			}
@@ -298,7 +298,7 @@ func TestListWorkflowRuns(t *testing.T) {
 		for i := 0; i < len(codesets); i++ {
 			filterCodesetProject := domain.WorkflowRunFilter{ByLabel: []string{fmt.Sprintf("%s=%s", LabelCodesetProject, codesets[i].Project)}}
 			want := []*workflow.WorkflowRun{wants[i]}
-			got, err := b.ListWorkflowRuns(ctx, w, filterCodesetProject)
+			got, err := b.ListWorkflowRuns(ctx, &w, &filterCodesetProject)
 			if err != nil {
 				t.Fatalf("Failed to list WorkflowRun: %s", err)
 			}
@@ -312,7 +312,7 @@ func TestListWorkflowRuns(t *testing.T) {
 			filterCodesetNameProject := domain.WorkflowRunFilter{ByLabel: []string{fmt.Sprintf("%s=%s", LabelCodesetName, codesets[i].Name),
 				fmt.Sprintf("%s=%s", LabelCodesetProject, codesets[i].Project)}}
 			want := []*workflow.WorkflowRun{wants[i]}
-			got, err := b.ListWorkflowRuns(ctx, w, filterCodesetNameProject)
+			got, err := b.ListWorkflowRuns(ctx, &w, &filterCodesetNameProject)
 			if err != nil {
 				t.Fatalf("Failed to list WorkflowRun: %s", err)
 			}
@@ -365,7 +365,7 @@ func TestListWorkflowRuns(t *testing.T) {
 
 		filterNil := domain.WorkflowRunFilter{ByStatus: nil}
 		want := wants
-		got, err := b.ListWorkflowRuns(ctx, w, filterNil)
+		got, err := b.ListWorkflowRuns(ctx, &w, &filterNil)
 		if err != nil {
 			t.Fatalf("Failed to list WorkflowRun: %s", err)
 		}
@@ -375,7 +375,7 @@ func TestListWorkflowRuns(t *testing.T) {
 
 		filterEmpty := domain.WorkflowRunFilter{ByStatus: []string{}}
 		want = wants
-		got, err = b.ListWorkflowRuns(ctx, w, filterEmpty)
+		got, err = b.ListWorkflowRuns(ctx, &w, &filterEmpty)
 		if err != nil {
 			t.Fatalf("Failed to list WorkflowRun: %s", err)
 		}
@@ -385,7 +385,7 @@ func TestListWorkflowRuns(t *testing.T) {
 
 		filterNoResult := domain.WorkflowRunFilter{ByStatus: []string{"Timeout"}}
 		want = []*workflow.WorkflowRun{}
-		got, err = b.ListWorkflowRuns(ctx, w, filterNoResult)
+		got, err = b.ListWorkflowRuns(ctx, &w, &filterNoResult)
 		if err != nil {
 			t.Fatalf("Failed to list WorkflowRun: %s", err)
 		}
@@ -396,7 +396,7 @@ func TestListWorkflowRuns(t *testing.T) {
 		for i := 0; i < len(runsStatus); i++ {
 			filterStatus := domain.WorkflowRunFilter{ByStatus: []string{pipelineReasonToWorkflowStatus(runsStatus[i])}}
 			want := []*workflow.WorkflowRun{wants[i]}
-			got, err := b.ListWorkflowRuns(ctx, w, filterStatus)
+			got, err := b.ListWorkflowRuns(ctx, &w, &filterStatus)
 			if err != nil {
 				t.Fatalf("Failed to list WorkflowRun: %s", err)
 			}
@@ -410,7 +410,7 @@ func TestListWorkflowRuns(t *testing.T) {
 			filterMultipleStatus.ByStatus = append(filterMultipleStatus.ByStatus, pipelineReasonToWorkflowStatus(runsStatus[i]))
 		}
 		want = wants
-		got, err = b.ListWorkflowRuns(ctx, w, filterMultipleStatus)
+		got, err = b.ListWorkflowRuns(ctx, &w, &filterMultipleStatus)
 		if err != nil {
 			t.Fatalf("Failed to list WorkflowRun: %s", err)
 		}

--- a/pkg/core/tekton/tekton_test.go
+++ b/pkg/core/tekton/tekton_test.go
@@ -262,9 +262,9 @@ func TestListWorkflowRuns(t *testing.T) {
 			t.Errorf("Unexpected WorkflowRun: %s", diff.PrintWantGot(d))
 		}
 
-		filterEmpty := domain.WorkflowRunFilter{ByLabel: []string{}}
+		filterEmptyCsName := domain.WorkflowRunFilter{CodesetName: ""}
 		want = wants
-		got, err = b.ListWorkflowRuns(ctx, &w, &filterEmpty)
+		got, err = b.ListWorkflowRuns(ctx, &w, &filterEmptyCsName)
 		if err != nil {
 			t.Fatalf("Failed to list WorkflowRun: %s", err)
 		}
@@ -272,7 +272,17 @@ func TestListWorkflowRuns(t *testing.T) {
 			t.Errorf("Unexpected WorkflowRun: %s", diff.PrintWantGot(d))
 		}
 
-		filterNoResult := domain.WorkflowRunFilter{ByLabel: []string{fmt.Sprintf("%s=%s", LabelCodesetName, "do-no-exist")}}
+		filterEmptyCsProject := domain.WorkflowRunFilter{CodesetName: ""}
+		want = wants
+		got, err = b.ListWorkflowRuns(ctx, &w, &filterEmptyCsProject)
+		if err != nil {
+			t.Fatalf("Failed to list WorkflowRun: %s", err)
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("Unexpected WorkflowRun: %s", diff.PrintWantGot(d))
+		}
+
+		filterNoResult := domain.WorkflowRunFilter{CodesetName: "do-no-exist"}
 		want = []*workflow.WorkflowRun{}
 		got, err = b.ListWorkflowRuns(ctx, &w, &filterNoResult)
 		if err != nil {
@@ -283,7 +293,7 @@ func TestListWorkflowRuns(t *testing.T) {
 		}
 
 		for i := 0; i < len(codesets); i++ {
-			filterCodesetName := domain.WorkflowRunFilter{ByLabel: []string{fmt.Sprintf("%s=%s", LabelCodesetName, codesets[i].Name)}}
+			filterCodesetName := domain.WorkflowRunFilter{CodesetName: codesets[i].Name}
 			want := []*workflow.WorkflowRun{wants[i]}
 			got, err := b.ListWorkflowRuns(ctx, &w, &filterCodesetName)
 			if err != nil {
@@ -296,7 +306,7 @@ func TestListWorkflowRuns(t *testing.T) {
 		}
 
 		for i := 0; i < len(codesets); i++ {
-			filterCodesetProject := domain.WorkflowRunFilter{ByLabel: []string{fmt.Sprintf("%s=%s", LabelCodesetProject, codesets[i].Project)}}
+			filterCodesetProject := domain.WorkflowRunFilter{CodesetProject: codesets[i].Project}
 			want := []*workflow.WorkflowRun{wants[i]}
 			got, err := b.ListWorkflowRuns(ctx, &w, &filterCodesetProject)
 			if err != nil {
@@ -309,8 +319,7 @@ func TestListWorkflowRuns(t *testing.T) {
 		}
 
 		for i := 0; i < len(codesets); i++ {
-			filterCodesetNameProject := domain.WorkflowRunFilter{ByLabel: []string{fmt.Sprintf("%s=%s", LabelCodesetName, codesets[i].Name),
-				fmt.Sprintf("%s=%s", LabelCodesetProject, codesets[i].Project)}}
+			filterCodesetNameProject := domain.WorkflowRunFilter{CodesetName: codesets[i].Name, CodesetProject: codesets[i].Project}
 			want := []*workflow.WorkflowRun{wants[i]}
 			got, err := b.ListWorkflowRuns(ctx, &w, &filterCodesetNameProject)
 			if err != nil {
@@ -363,7 +372,7 @@ func TestListWorkflowRuns(t *testing.T) {
 			})
 		}
 
-		filterNil := domain.WorkflowRunFilter{ByStatus: nil}
+		filterNil := domain.WorkflowRunFilter{Status: nil}
 		want := wants
 		got, err := b.ListWorkflowRuns(ctx, &w, &filterNil)
 		if err != nil {
@@ -373,7 +382,7 @@ func TestListWorkflowRuns(t *testing.T) {
 			t.Errorf("Unexpected WorkflowRun: %s", diff.PrintWantGot(d))
 		}
 
-		filterEmpty := domain.WorkflowRunFilter{ByStatus: []string{}}
+		filterEmpty := domain.WorkflowRunFilter{Status: []string{}}
 		want = wants
 		got, err = b.ListWorkflowRuns(ctx, &w, &filterEmpty)
 		if err != nil {
@@ -383,7 +392,7 @@ func TestListWorkflowRuns(t *testing.T) {
 			t.Errorf("Unexpected WorkflowRun: %s", diff.PrintWantGot(d))
 		}
 
-		filterNoResult := domain.WorkflowRunFilter{ByStatus: []string{"Timeout"}}
+		filterNoResult := domain.WorkflowRunFilter{Status: []string{"Timeout"}}
 		want = []*workflow.WorkflowRun{}
 		got, err = b.ListWorkflowRuns(ctx, &w, &filterNoResult)
 		if err != nil {
@@ -394,7 +403,7 @@ func TestListWorkflowRuns(t *testing.T) {
 		}
 
 		for i := 0; i < len(runsStatus); i++ {
-			filterStatus := domain.WorkflowRunFilter{ByStatus: []string{pipelineReasonToWorkflowStatus(runsStatus[i])}}
+			filterStatus := domain.WorkflowRunFilter{Status: []string{pipelineReasonToWorkflowStatus(runsStatus[i])}}
 			want := []*workflow.WorkflowRun{wants[i]}
 			got, err := b.ListWorkflowRuns(ctx, &w, &filterStatus)
 			if err != nil {
@@ -407,7 +416,7 @@ func TestListWorkflowRuns(t *testing.T) {
 
 		filterMultipleStatus := domain.WorkflowRunFilter{}
 		for i := 0; i < len(runsStatus); i++ {
-			filterMultipleStatus.ByStatus = append(filterMultipleStatus.ByStatus, pipelineReasonToWorkflowStatus(runsStatus[i]))
+			filterMultipleStatus.Status = append(filterMultipleStatus.Status, pipelineReasonToWorkflowStatus(runsStatus[i]))
 		}
 		want = wants
 		got, err = b.ListWorkflowRuns(ctx, &w, &filterMultipleStatus)

--- a/pkg/core/tekton/tekton_test.go
+++ b/pkg/core/tekton/tekton_test.go
@@ -43,12 +43,12 @@ const (
 
 func TestCreateWorkflow(t *testing.T) {
 	t.Run("new workflow", func(t *testing.T) {
-		ctx, b, logs, logsOutput := initBackend(t)
+		ctx, b, logsOutput := initBackend(t)
 
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, logs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 
 		assertError(t, err, nil)
 		assertStrings(t, strings.TrimSuffix(logsOutput.String(), "\n"), "Creating tekton pipeline for workflow: mlflow-sklearn-e2e...")
@@ -68,36 +68,34 @@ func TestCreateWorkflow(t *testing.T) {
 	})
 
 	t.Run("existing workflow", func(t *testing.T) {
-		ctx, b, logs, _ := initBackend(t)
+		ctx, b, _ := initBackend(t)
 
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, logs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
-		got := b.CreateWorkflow(ctx, logs, &w)
+		got := b.CreateWorkflow(ctx, &w)
 		assertError(t, got, errWorkflowExists)
 	})
 }
 
 func TestDeleteWorkflow(t *testing.T) {
 	t.Run("delete", func(t *testing.T) {
-		ctx, b, logs, logsOutput := initBackend(t)
-
-		discardOutput := bytes.Buffer{}
-		discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
+		ctx, b, logsOutput := initBackend(t)
 
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, discardLogs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
+		logsOutput.Reset()
 
-		err = b.DeleteWorkflow(ctx, logs, w.Name)
+		err = b.DeleteWorkflow(ctx, w.Name)
 
 		assertError(t, err, nil)
 
@@ -114,10 +112,10 @@ func TestDeleteWorkflow(t *testing.T) {
 	})
 
 	t.Run("skip not found", func(t *testing.T) {
-		ctx, b, logs, logsOutput := initBackend(t)
+		ctx, b, logsOutput := initBackend(t)
 
 		name := "TestWorkflow"
-		err := b.DeleteWorkflow(ctx, logs, name)
+		err := b.DeleteWorkflow(ctx, name)
 
 		assertError(t, err, nil)
 
@@ -129,24 +127,23 @@ Tekton pipeline %q not found, skipping delete...
 }
 
 func TestCreateWorkflowRun(t *testing.T) {
-	ctx, b, logs, logsOutput := initBackend(t)
+	ctx, b, logsOutput := initBackend(t)
 
-	discardOutput := bytes.Buffer{}
-	discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
 	w := workflow.Workflow{}
 	readYaml(t, fuseMLWorkflow, &w)
 
-	err := b.CreateWorkflow(ctx, discardLogs, &w)
+	err := b.CreateWorkflow(ctx, &w)
 	if err != nil {
 		t.Fatal(err)
 	}
+	logsOutput.Reset()
 
 	cs := &domain.Codeset{
 		Name:    "mlflow-app-01",
 		Project: "workspace",
 		URL:     "http://gitea.10.160.5.140.nip.io/workspace/mlflow-app-01.git",
 	}
-	err = b.CreateWorkflowRun(ctx, logs, w.Name, cs)
+	err = b.CreateWorkflowRun(ctx, w.Name, cs)
 	if err != nil {
 		t.Fatalf("Failed to create workflow run %q: %s", w.Name, err)
 	}
@@ -175,12 +172,12 @@ func TestCreateWorkflowRun(t *testing.T) {
 
 func TestListWorkflowRuns(t *testing.T) {
 	t.Run("all", func(t *testing.T) {
-		ctx, b, logs, _ := initBackend(t)
+		ctx, b, _ := initBackend(t)
 
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, logs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -193,7 +190,7 @@ func TestListWorkflowRuns(t *testing.T) {
 			runName := fmt.Sprintf("%s-%d", w.Name, i)
 			runURL := "http://tekton.test/#/namespaces/test-namespace/pipelineruns/" + runName
 			runStartTime := metav1.Now()
-			b.createTestWorkflowRun(ctx, t, logs, w.Name, cs, runName, runStatus, runStartTime)
+			b.createTestWorkflowRun(ctx, t, w.Name, cs, runName, runStatus, runStartTime)
 			runCsInputValue := fmt.Sprintf("%s:main", cs.URL)
 			startTime := runStartTime.Format(time.RFC3339)
 			completionTime := metav1.NewTime(runStartTime.Time.Add(time.Minute)).Format(time.RFC3339)
@@ -219,13 +216,13 @@ func TestListWorkflowRuns(t *testing.T) {
 		}
 	})
 
-	t.Run("filter by label", func(t *testing.T) {
-		ctx, b, logs, _ := initBackend(t)
+	t.Run("filter by codeset", func(t *testing.T) {
+		ctx, b, _ := initBackend(t)
 
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, logs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -238,7 +235,7 @@ func TestListWorkflowRuns(t *testing.T) {
 			runName := fmt.Sprintf("%s-%d", w.Name, i)
 			runURL := "http://tekton.test/#/namespaces/test-namespace/pipelineruns/" + runName
 			runStartTime := metav1.Now()
-			b.createTestWorkflowRun(ctx, t, logs, w.Name, cs, runName, runStatus, runStartTime)
+			b.createTestWorkflowRun(ctx, t, w.Name, cs, runName, runStatus, runStartTime)
 			runCsInputValue := fmt.Sprintf("%s:main", cs.URL)
 			startTime := runStartTime.Format(time.RFC3339)
 			completionTime := metav1.NewTime(runStartTime.Time.Add(time.Minute)).Format(time.RFC3339)
@@ -327,12 +324,12 @@ func TestListWorkflowRuns(t *testing.T) {
 	})
 
 	t.Run("filter by status", func(t *testing.T) {
-		ctx, b, logs, _ := initBackend(t)
+		ctx, b, _ := initBackend(t)
 
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, logs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -345,7 +342,7 @@ func TestListWorkflowRuns(t *testing.T) {
 			runURL := "http://tekton.test/#/namespaces/test-namespace/pipelineruns/" + runName
 			runStartTime := metav1.Now()
 			runStatus := runsStatus[i]
-			b.createTestWorkflowRun(ctx, t, logs, w.Name, cs, runName, runStatus, runStartTime)
+			b.createTestWorkflowRun(ctx, t, w.Name, cs, runName, runStatus, runStartTime)
 			startTime := runStartTime.Format(time.RFC3339)
 			var completionTime *string
 			if runStatus != "Running" {
@@ -427,19 +424,18 @@ func TestListWorkflowRuns(t *testing.T) {
 
 func TestCreateWorkflowListener(t *testing.T) {
 	t.Run("new listener", func(t *testing.T) {
-		ctx, b, logs, logsOutput := initBackend(t)
+		ctx, b, logsOutput := initBackend(t)
 
-		discardOutput := bytes.Buffer{}
-		discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, discardLogs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
+		logsOutput.Reset()
 
-		wfListener, err := b.CreateWorkflowListener(ctx, logs, w.Name, 0)
+		wfListener, err := b.CreateWorkflowListener(ctx, w.Name, 0)
 		assertError(t, err, nil)
 
 		wantURL := fmt.Sprintf("http://el-%s.%s.svc.cluster.local:8080", w.Name, b.namespace)
@@ -509,24 +505,23 @@ Creating tekton event listener for workflow: mlflow-sklearn-e2e...
 	})
 
 	t.Run("existing listener", func(t *testing.T) {
-		ctx, b, logs, logsOutput := initBackend(t)
+		ctx, b, logsOutput := initBackend(t)
 
-		discardOutput := bytes.Buffer{}
-		discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, discardLogs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		_, err = b.CreateWorkflowListener(ctx, discardLogs, w.Name, 0)
+		_, err = b.CreateWorkflowListener(ctx, w.Name, 0)
 		if err != nil {
 			t.Fatalf("Failed to create listener for workflow %q: %s", w.Name, err)
 		}
+		logsOutput.Reset()
 
-		wfListener, err := b.CreateWorkflowListener(ctx, logs, w.Name, 0)
+		wfListener, err := b.CreateWorkflowListener(ctx, w.Name, 0)
 		assertError(t, err, nil)
 
 		wantURL := fmt.Sprintf("http://el-%s.%s.svc.cluster.local:8080", w.Name, b.namespace)
@@ -547,19 +542,18 @@ Creating tekton event listener for workflow: mlflow-sklearn-e2e...
 	})
 
 	t.Run("clean if fail", func(t *testing.T) {
-		ctx, b, logs, logsOutput := initBackend(t)
+		ctx, b, logsOutput := initBackend(t)
 
-		discardOutput := bytes.Buffer{}
-		discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, discardLogs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
+		logsOutput.Reset()
 
-		_, err = b.CreateWorkflowListener(ctx, logs, w.Name, 1*time.Nanosecond)
+		_, err = b.CreateWorkflowListener(ctx, w.Name, 1*time.Nanosecond)
 		assertError(t, err, errWaitListenerTimeout)
 
 		templates, err := b.tektonClients.TriggerTemplateClient.List(ctx, metav1.ListOptions{})
@@ -600,24 +594,23 @@ Deleting TriggerTemplate: mlflow-sklearn-e2e... (creating listener failed)
 
 func TestDeleteWorkflowListener(t *testing.T) {
 	t.Run("delete", func(t *testing.T) {
-		ctx, b, logs, logsOutput := initBackend(t)
+		ctx, b, logsOutput := initBackend(t)
 
-		discardOutput := bytes.Buffer{}
-		discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
 		w := workflow.Workflow{}
 		readYaml(t, fuseMLWorkflow, &w)
 
-		err := b.CreateWorkflow(ctx, discardLogs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		wfListener, err := b.CreateWorkflowListener(ctx, discardLogs, w.Name, 0)
+		wfListener, err := b.CreateWorkflowListener(ctx, w.Name, 0)
 		if err != nil {
 			t.Fatalf("Failed to create listener for workflow %q: %s", w.Name, err)
 		}
+		logsOutput.Reset()
 
-		err = b.DeleteWorkflowListener(ctx, logs, wfListener.Name)
+		err = b.DeleteWorkflowListener(ctx, wfListener.Name)
 		assertError(t, err, nil)
 
 		els, err := b.tektonClients.EventListenerClient.List(ctx, metav1.ListOptions{})
@@ -652,10 +645,10 @@ Deleting tekton trigger template: %s...
 	})
 
 	t.Run("skip not found", func(t *testing.T) {
-		ctx, b, logs, logsOutput := initBackend(t)
+		ctx, b, logsOutput := initBackend(t)
 
 		name := "TestListener"
-		err := b.DeleteWorkflowListener(ctx, logs, name)
+		err := b.DeleteWorkflowListener(ctx, name)
 		assertError(t, err, nil)
 
 		expectedLog := fmt.Sprintf(`Deleting tekton event listener: %s...
@@ -670,10 +663,8 @@ Tekton trigger template %q not found, skipping delete...
 }
 
 func TestGetWorkflowListener(t *testing.T) {
-	ctx, b, _, _ := initBackend(t)
+	ctx, b, _ := initBackend(t)
 
-	discardOutput := bytes.Buffer{}
-	discardLogs := log.New(&discardOutput, "[tekton-test] ", log.Ltime)
 	w := workflow.Workflow{}
 	readYaml(t, fuseMLWorkflow, &w)
 
@@ -682,7 +673,7 @@ func TestGetWorkflowListener(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		listenerName := fmt.Sprintf("%s-%d", wfName, i)
 		w.Name = listenerName
-		err := b.CreateWorkflow(ctx, discardLogs, &w)
+		err := b.CreateWorkflow(ctx, &w)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -694,7 +685,7 @@ func TestGetWorkflowListener(t *testing.T) {
 			url = fmt.Sprintf("http://el-%s.%s.svc.cluster.local:8080", listenerName, b.namespace)
 		}
 
-		b.createTestListener(ctx, t, discardLogs, listenerName, available)
+		b.createTestListener(ctx, t, listenerName, available)
 		wants = append(wants, &domain.WorkflowListener{
 			Name:         listenerName,
 			URL:          url,
@@ -731,14 +722,13 @@ func assertStrings(t testing.TB, got, want string) {
 	}
 }
 
-func initBackend(t *testing.T) (context context.Context, backend *WorkflowBackend, logs *log.Logger, logsOutput *bytes.Buffer) {
+func initBackend(t *testing.T) (context context.Context, backend *WorkflowBackend, logsOutput *bytes.Buffer) {
 	t.Helper()
 
 	context, _ = rtesting.SetupFakeContext(t)
-	backend = fakeNewWorkflowBackend(context, t, testNamespace)
-
 	logsOutput = &bytes.Buffer{}
-	logs = log.New(logsOutput, "", 0)
+	logger := log.New(logsOutput, "", 0)
+	backend = fakeNewWorkflowBackend(context, t, logger, testNamespace)
 	return
 }
 
@@ -782,11 +772,11 @@ func newFakeClients(context context.Context, t *testing.T, namespace string) *cl
 	return fc
 }
 
-func fakeNewWorkflowBackend(context context.Context, t *testing.T, namespace string) *WorkflowBackend {
+func fakeNewWorkflowBackend(context context.Context, t *testing.T, logger *log.Logger, namespace string) *WorkflowBackend {
 	t.Helper()
 
 	clients := newFakeClients(context, t, namespace)
-	return &WorkflowBackend{"http://tekton.test", namespace, clients}
+	return &WorkflowBackend{"http://tekton.test", namespace, logger, clients}
 }
 
 func createCodeset(t *testing.T, nameID, projectID int) *domain.Codeset {
@@ -798,11 +788,11 @@ func createCodeset(t *testing.T, nameID, projectID int) *domain.Codeset {
 	return &domain.Codeset{Name: name, Project: project, URL: url}
 }
 
-func (b WorkflowBackend) createTestWorkflowRun(ctx context.Context, t *testing.T, log *log.Logger,
-	workflow string, cs *domain.Codeset, runName string, status string, startTime metav1.Time) {
+func (b WorkflowBackend) createTestWorkflowRun(ctx context.Context, t *testing.T, workflow string,
+	cs *domain.Codeset, runName string, status string, startTime metav1.Time) {
 	t.Helper()
 
-	err := b.CreateWorkflowRun(ctx, log, workflow, cs)
+	err := b.CreateWorkflowRun(ctx, workflow, cs)
 	if err != nil {
 		t.Fatalf("Failed to create workflow run %q: %s", workflow, err)
 	}
@@ -832,10 +822,10 @@ func (b WorkflowBackend) createTestWorkflowRun(ctx context.Context, t *testing.T
 	}
 }
 
-func (b WorkflowBackend) createTestListener(ctx context.Context, t *testing.T, logger *log.Logger, workflow string, available bool) {
+func (b WorkflowBackend) createTestListener(ctx context.Context, t *testing.T, workflow string, available bool) {
 	t.Helper()
 
-	_, err := b.CreateWorkflowListener(ctx, logger, workflow, 0)
+	_, err := b.CreateWorkflowListener(ctx, workflow, 0)
 	if err != nil {
 		t.Fatalf("Failed to create listener %q: %s", workflow, err)
 	}

--- a/pkg/core/tekton/tekton_test.go
+++ b/pkg/core/tekton/tekton_test.go
@@ -78,7 +78,7 @@ func TestCreateWorkflow(t *testing.T) {
 			t.Fatal(err)
 		}
 		got := b.CreateWorkflow(ctx, &w)
-		assertError(t, got, errWorkflowExists)
+		assertError(t, got, domain.ErrWorkflowExists)
 	})
 }
 

--- a/pkg/core/workflow_store.go
+++ b/pkg/core/workflow_store.go
@@ -41,8 +41,12 @@ func (ws *WorkflowStore) GetWorkflow(ctx context.Context, name string) (*workflo
 func (ws *WorkflowStore) GetWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow) {
 	result = make([]*workflow.Workflow, 0, len(ws.items))
 	if name != nil {
-		result = append(result, ws.items[*name].workflow)
-		return
+		if sw, ok := ws.items[*name]; ok {
+			result = append(result, sw.workflow)
+			return
+		}
+		return result
+
 	}
 	for _, sw := range ws.items {
 		result = append(result, sw.workflow)

--- a/pkg/core/workflow_store.go
+++ b/pkg/core/workflow_store.go
@@ -30,11 +30,11 @@ func NewWorkflowStore() *WorkflowStore {
 }
 
 // GetWorkflow returns a workflow identified by its name
-func (ws *WorkflowStore) GetWorkflow(ctx context.Context, name string) *workflow.Workflow {
+func (ws *WorkflowStore) GetWorkflow(ctx context.Context, name string) (*workflow.Workflow, error) {
 	if _, exists := ws.items[name]; exists {
-		return ws.items[name].workflow
+		return ws.items[name].workflow, nil
 	}
-	return nil
+	return nil, domain.ErrWorkflowNotFound
 }
 
 // GetWorkflows returns all workflows or the one that matches a given name.

--- a/pkg/core/workflow_store.go
+++ b/pkg/core/workflow_store.go
@@ -126,13 +126,16 @@ func (ws *WorkflowStore) DeleteCodesetAssignment(ctx context.Context, workflowNa
 }
 
 // GetAssignedCodeset returns a AssignedCodeset for the Workflow and Codeset
-func (ws *WorkflowStore) GetAssignedCodeset(ctx context.Context, workflowName string, codeset *domain.Codeset) *domain.AssignedCodeset {
+func (ws *WorkflowStore) GetAssignedCodeset(ctx context.Context, workflowName string, codeset *domain.Codeset) (*domain.AssignedCodeset, error) {
 	sw, exists := ws.items[workflowName]
 	if !exists {
-		return nil
+		return nil, domain.ErrWorkflowNotFound
 	}
 	ac, _ := getAssignedCodeset(sw.assignedCodesets, codeset)
-	return ac
+	if ac == nil {
+		return nil, domain.ErrWorkflowNotAssignedToCodeset
+	}
+	return ac, nil
 }
 
 func getAssignedCodeset(assignedCodesets []*domain.AssignedCodeset, codeset *domain.Codeset) (*domain.AssignedCodeset, int) {

--- a/pkg/core/workflow_store.go
+++ b/pkg/core/workflow_store.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/fuseml/fuseml-core/gen/workflow"
 	"github.com/fuseml/fuseml-core/pkg/domain"
@@ -57,10 +56,8 @@ func (ws *WorkflowStore) GetWorkflows(ctx context.Context, name *string) (result
 // AddWorkflow adds a new workflow based on the Workflow structure provided as argument
 func (ws *WorkflowStore) AddWorkflow(ctx context.Context, w *workflow.Workflow) (*workflow.Workflow, error) {
 	if _, exists := ws.items[w.Name]; exists {
-		return nil, fmt.Errorf("workflow %q already exists", w.Name)
+		return nil, domain.ErrWorkflowExists
 	}
-	workflowCreated := time.Now().Format(time.RFC3339)
-	w.Created = &workflowCreated
 	sw := storableWorkflow{workflow: w}
 	ws.items[w.Name] = &sw
 	return w, nil

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -24,6 +24,18 @@ func (e WorkflowErr) Error() string {
 	return string(e)
 }
 
+// WorkflowManager describes the interface for a Workflow Manager
+type WorkflowManager interface {
+	Create(ctx context.Context, workflow *workflow.Workflow) (*workflow.Workflow, error)
+	Get(ctx context.Context, name string) (*workflow.Workflow, error)
+	Delete(ctx context.Context, name string) error
+	List(ctx context.Context, name *string) []*workflow.Workflow
+	AssignToCodeset(ctx context.Context, name, codesetProject, codesetName string) (*WorkflowListener, *int64, error)
+	UnassignFromCodeset(ctx context.Context, name, codesetProject, codesetName string) error
+	ListAssignments(ctx context.Context, name *string) ([]*workflow.WorkflowAssignment, error)
+	ListRuns(ctx context.Context, filter *WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
+}
+
 // WorkflowStore is an interface to workflow stores
 type WorkflowStore interface {
 	GetWorkflow(ctx context.Context, name string) *workflow.Workflow

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -38,8 +38,8 @@ type WorkflowManager interface {
 
 // WorkflowStore is an interface to workflow stores
 type WorkflowStore interface {
-	GetWorkflow(ctx context.Context, name string) *workflow.Workflow
-	GetWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow)
+	GetWorkflow(ctx context.Context, name string) (*workflow.Workflow, error)
+	GetWorkflows(ctx context.Context, name *string) []*workflow.Workflow
 	AddWorkflow(ctx context.Context, w *workflow.Workflow) (*workflow.Workflow, error)
 	DeleteWorkflow(ctx context.Context, name string) error
 	GetAssignedCodeset(ctx context.Context, workflowName string, codeset *Codeset) *AssignedCodeset

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -42,7 +42,7 @@ type WorkflowStore interface {
 	GetWorkflows(ctx context.Context, name *string) []*workflow.Workflow
 	AddWorkflow(ctx context.Context, w *workflow.Workflow) (*workflow.Workflow, error)
 	DeleteWorkflow(ctx context.Context, name string) error
-	GetAssignedCodeset(ctx context.Context, workflowName string, codeset *Codeset) *AssignedCodeset
+	GetAssignedCodeset(ctx context.Context, workflowName string, codeset *Codeset) (*AssignedCodeset, error)
 	GetAssignedCodesets(ctx context.Context, workflowName string) []*AssignedCodeset
 	GetAssignments(ctx context.Context, workflowName *string) map[string][]*AssignedCodeset
 	AddCodesetAssignment(ctx context.Context, workflowName string, assignedCodeset *AssignedCodeset) []*AssignedCodeset

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -33,8 +33,10 @@ type WorkflowBackend interface {
 
 // WorkflowRunFilter defines the available filter when listing workflow runs
 type WorkflowRunFilter struct {
-	ByLabel  []string
-	ByStatus []string
+	WorkflowName   *string
+	CodesetName    string
+	CodesetProject string
+	Status         []string
 }
 
 // WorkflowListener defines a listener for a workflow

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/fuseml/fuseml-core/gen/workflow"
@@ -23,12 +22,12 @@ type WorkflowStore interface {
 
 // WorkflowBackend is the interface for the FuseML workflows
 type WorkflowBackend interface {
-	CreateWorkflow(ctx context.Context, logger *log.Logger, workflow *workflow.Workflow) error
-	DeleteWorkflow(ctx context.Context, logger *log.Logger, workflowName string) error
-	CreateWorkflowRun(ctx context.Context, logger *log.Logger, workflowName string, codeset *Codeset) error
+	CreateWorkflow(ctx context.Context, workflow *workflow.Workflow) error
+	DeleteWorkflow(ctx context.Context, workflowName string) error
+	CreateWorkflowRun(ctx context.Context, workflowName string, codeset *Codeset) error
 	ListWorkflowRuns(ctx context.Context, workflow workflow.Workflow, filter WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
-	CreateWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string, timeout time.Duration) (*WorkflowListener, error)
-	DeleteWorkflowListener(ctx context.Context, logger *log.Logger, workflowName string) error
+	CreateWorkflowListener(ctx context.Context, workflowName string, timeout time.Duration) (*WorkflowListener, error)
+	DeleteWorkflowListener(ctx context.Context, workflowName string) error
 	GetWorkflowListener(ctx context.Context, workflowName string) (*WorkflowListener, error)
 }
 

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -7,7 +7,24 @@ import (
 	"github.com/fuseml/fuseml-core/gen/workflow"
 )
 
-// WorkflowStore is an inteface to workflow stores
+const (
+	// ErrWorkflowExists describes the error message returned when trying to create a workflow with that already exists.
+	ErrWorkflowExists = WorkflowErr("workflow already exists")
+	// ErrWorkflowNotFound describes the error message returned when trying to get a workflow that does not exist.
+	ErrWorkflowNotFound = WorkflowErr("could not find a workflow with the specified name")
+	// ErrWorkflowNotAssignedToCodeset describes the error message returned when trying to unassign a workflow from a codeset
+	// but it is not assigned to the codeset.
+	ErrWorkflowNotAssignedToCodeset = WorkflowErr("workflow not assigned to codeset")
+)
+
+// WorkflowErr are expected errors returned when performing operations on workflows
+type WorkflowErr string
+
+func (e WorkflowErr) Error() string {
+	return string(e)
+}
+
+// WorkflowStore is an interface to workflow stores
 type WorkflowStore interface {
 	GetWorkflow(ctx context.Context, name string) *workflow.Workflow
 	GetWorkflows(ctx context.Context, name *string) (result []*workflow.Workflow)

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -25,7 +25,7 @@ type WorkflowBackend interface {
 	CreateWorkflow(ctx context.Context, workflow *workflow.Workflow) error
 	DeleteWorkflow(ctx context.Context, workflowName string) error
 	CreateWorkflowRun(ctx context.Context, workflowName string, codeset *Codeset) error
-	ListWorkflowRuns(ctx context.Context, workflow workflow.Workflow, filter WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
+	ListWorkflowRuns(ctx context.Context, workflow *workflow.Workflow, filter *WorkflowRunFilter) ([]*workflow.WorkflowRun, error)
 	CreateWorkflowListener(ctx context.Context, workflowName string, timeout time.Duration) (*WorkflowListener, error)
 	DeleteWorkflowListener(ctx context.Context, workflowName string) error
 	GetWorkflowListener(ctx context.Context, workflowName string) (*WorkflowListener, error)

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -169,14 +169,15 @@ func (s *workflowsrvc) ListRuns(ctx context.Context, w *workflow.ListRunsPayload
 	workflowRuns := []*workflow.WorkflowRun{}
 	workflows := s.store.GetWorkflows(ctx, w.Name)
 	filters := domain.WorkflowRunFilter{}
+	filter := domain.WorkflowRunFilter{WorkflowName: w.Name}
 	if w.CodesetName != nil {
-		filters.ByLabel = append(filters.ByLabel, fmt.Sprintf("%s=%s", tekton.LabelCodesetName, *w.CodesetName))
+		filter.CodesetName = *w.CodesetName
 	}
 	if w.CodesetProject != nil {
-		filters.ByLabel = append(filters.ByLabel, fmt.Sprintf("%s=%s", tekton.LabelCodesetProject, *w.CodesetProject))
+		filter.CodesetProject = *w.CodesetProject
 	}
 	if w.Status != nil {
-		filters.ByStatus = append(filters.ByStatus, *w.Status)
+		filter.Status = []string{*w.Status}
 	}
 
 	for _, workflow := range workflows {

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -2,173 +2,111 @@ package svc
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log"
-	"time"
+	"strings"
 
 	"github.com/fuseml/fuseml-core/gen/workflow"
-	"github.com/fuseml/fuseml-core/pkg/core/config"
-	"github.com/fuseml/fuseml-core/pkg/core/tekton"
 	"github.com/fuseml/fuseml-core/pkg/domain"
 )
-
-// createWorkflowListenerTimeout is the time (in minutes) that FuseML waits for the workflow listener
-// to be available
-const createWorkflowListenerTimeout = 1
 
 // workflow service example implementation.
 // The example methods log the requests and return zero values.
 type workflowsrvc struct {
-	logger       *log.Logger
-	store        domain.WorkflowStore
-	codesetStore domain.CodesetStore
-	backend      domain.WorkflowBackend
+	logger *log.Logger
+	mgr    domain.WorkflowManager
 }
 
 // NewWorkflowService returns the workflow service implementation.
-func NewWorkflowService(logger *log.Logger, store domain.WorkflowStore, codesetStore domain.CodesetStore) (workflow.Service, error) {
-	backend, err := tekton.NewWorkflowBackend(logger, config.FuseMLNamespace)
-	if err != nil {
-		return nil, err
-	}
-	return &workflowsrvc{logger, store, codesetStore, backend}, nil
+func NewWorkflowService(logger *log.Logger, workflowManager domain.WorkflowManager) workflow.Service {
+	return &workflowsrvc{logger, workflowManager}
 }
 
 // List Workflows.
 func (s *workflowsrvc) List(ctx context.Context, w *workflow.ListPayload) (res []*workflow.Workflow, err error) {
 	s.logger.Print("workflow.list")
-	return s.store.GetWorkflows(ctx, w.Name), nil
+	return s.mgr.List(ctx, w.Name), nil
 }
 
 // Create a new Workflow.
 func (s *workflowsrvc) Create(ctx context.Context, w *workflow.Workflow) (res *workflow.Workflow, err error) {
 	s.logger.Print("workflow.create")
-	err = s.backend.CreateWorkflow(ctx, w)
+	res, err = s.mgr.Create(ctx, w)
 	if err != nil {
 		s.logger.Print(err)
-		if err.Error() == "workflow already exists" {
+		if err == domain.ErrWorkflowExists {
 			return nil, workflow.MakeConflict(err)
 		}
 		return nil, err
 	}
-	return s.store.AddWorkflow(ctx, w)
+	return
 }
 
 // Get a Workflow.
 func (s *workflowsrvc) Get(ctx context.Context, w *workflow.GetPayload) (res *workflow.Workflow, err error) {
 	s.logger.Print("workflow.get")
-	return s.getWorkflow(ctx, w.Name)
+	res, err = s.mgr.Get(ctx, w.Name)
+	if err != nil {
+		s.logger.Print(err)
+		if err == domain.ErrWorkflowNotFound {
+			return nil, workflow.MakeNotFound(err)
+		}
+		return nil, err
+	}
+	return
 }
 
 // Delete a Workflow and its assignments.
 func (s *workflowsrvc) Delete(ctx context.Context, d *workflow.DeletePayload) (err error) {
 	s.logger.Print("workflow.delete")
-	if _, err := s.getWorkflow(ctx, d.Name); err != nil {
-		s.logger.Print(err)
-		return err
-	}
-
-	// unassign all assigned codesets, if there's any
-	assignedCodesets := s.store.GetAssignedCodesets(ctx, d.Name)
-	for _, ac := range assignedCodesets {
-		err := s.unassignCodesetFromWorkflow(ctx, d.Name, ac.Codeset)
-		if err != nil {
-			return err
-		}
-	}
-
-	// delete tekton pipeline
-	err = s.backend.DeleteWorkflow(ctx, d.Name)
+	err = s.mgr.Delete(ctx, d.Name)
 	if err != nil {
 		s.logger.Print(err)
-		return err
+		return
 	}
-
-	// delete workflow
-	err = s.store.DeleteWorkflow(ctx, d.Name)
-	if err != nil {
-		s.logger.Print(err)
-		return err
-	}
-	return nil
+	return
 }
 
 // Assign a Workflow to a Codeset.
 func (s *workflowsrvc) Assign(ctx context.Context, w *workflow.AssignPayload) (err error) {
 	s.logger.Print("workflow.assign")
-	if _, err = s.getWorkflow(ctx, w.Name); err != nil {
-		s.logger.Print(err)
-		return err
-	}
-
-	codeset, err := s.codesetStore.Find(ctx, w.CodesetProject, w.CodesetName)
+	_, _, err = s.mgr.AssignToCodeset(ctx, w.Name, w.CodesetProject, w.CodesetName)
 	if err != nil {
 		s.logger.Print(err)
-		return workflow.MakeNotFound(err)
+		// FIXME: codeset needs to thrown a known error when trying to get a codeset that does not exist
+		// to properly compare the returned error.
+		if err == domain.ErrWorkflowNotFound || strings.Contains(err.Error(), "Fetching Codeset failed") {
+			return workflow.MakeNotFound(err)
+		}
 	}
-
-	wfListener, err := s.backend.CreateWorkflowListener(ctx, w.Name, createWorkflowListenerTimeout*time.Minute)
-	if err != nil {
-		s.logger.Print(err)
-		return err
-	}
-
-	webhookID, err := s.codesetStore.CreateWebhook(ctx, codeset, wfListener.URL)
-	if err != nil {
-		s.logger.Print(err)
-		return err
-	}
-
-	s.store.AddCodesetAssignment(ctx, w.Name, &domain.AssignedCodeset{Codeset: codeset, WebhookID: webhookID})
-
-	err = s.backend.CreateWorkflowRun(ctx, w.Name, codeset)
-	if err != nil {
-		s.logger.Print(err)
-		return err
-	}
-	return nil
+	return
 }
 
 // Unassign a Workflow from a Codeset.
 func (s *workflowsrvc) Unassign(ctx context.Context, u *workflow.UnassignPayload) (err error) {
 	s.logger.Print("workflow.unassign")
-	codeset, err := s.codesetStore.Find(ctx, u.CodesetProject, u.CodesetName)
+	err = s.mgr.UnassignFromCodeset(ctx, u.Name, u.CodesetProject, u.CodesetName)
 	if err != nil {
 		s.logger.Print(err)
-		return workflow.MakeNotFound(err)
+		if err == domain.ErrWorkflowNotFound || strings.Contains(err.Error(), "Fetching Codeset failed") || err == domain.ErrWorkflowNotAssignedToCodeset {
+			return workflow.MakeNotFound(err)
+		}
 	}
-	return s.unassignCodesetFromWorkflow(ctx, u.Name, codeset)
+	return
 }
 
 // ListAssignments lists Workflow assignments.
-func (s *workflowsrvc) ListAssignments(ctx context.Context, w *workflow.ListAssignmentsPayload) (res []*workflow.WorkflowAssignment, err error) {
+func (s *workflowsrvc) ListAssignments(ctx context.Context, w *workflow.ListAssignmentsPayload) (assignments []*workflow.WorkflowAssignment, err error) {
 	s.logger.Print("workflow.listAssignments")
-	listeners := map[string]*domain.WorkflowListener{}
-	for wf, acs := range s.store.GetAssignments(ctx, w.Name) {
-		var listener *domain.WorkflowListener
-		if l, ok := listeners[wf]; ok {
-			listener = l
-		} else {
-			listener, err = s.backend.GetWorkflowListener(ctx, wf)
-			if err != nil {
-				s.logger.Print(err)
-				return nil, err
-			}
-			listeners[wf] = listener
-		}
-		assignment := newRestWorkflowAssignment(wf, acs, listener)
-		res = append(res, assignment)
+	assignments, err = s.mgr.ListAssignments(ctx, w.Name)
+	if err != nil {
+		return nil, err
 	}
 	return
 }
 
 // List Workflow runs.
-func (s *workflowsrvc) ListRuns(ctx context.Context, w *workflow.ListRunsPayload) ([]*workflow.WorkflowRun, error) {
+func (s *workflowsrvc) ListRuns(ctx context.Context, w *workflow.ListRunsPayload) (runs []*workflow.WorkflowRun, err error) {
 	s.logger.Print("workflow.listRuns")
-	workflowRuns := []*workflow.WorkflowRun{}
-	workflows := s.store.GetWorkflows(ctx, w.Name)
-	filters := domain.WorkflowRunFilter{}
 	filter := domain.WorkflowRunFilter{WorkflowName: w.Name}
 	if w.CodesetName != nil {
 		filter.CodesetName = *w.CodesetName
@@ -179,73 +117,9 @@ func (s *workflowsrvc) ListRuns(ctx context.Context, w *workflow.ListRunsPayload
 	if w.Status != nil {
 		filter.Status = []string{*w.Status}
 	}
-
-	for _, workflow := range workflows {
-		runs, err := s.backend.ListWorkflowRuns(ctx, workflow, &filters)
-		if err != nil {
-			s.logger.Print(err)
-			return nil, err
-		}
-		workflowRuns = append(workflowRuns, runs...)
+	runs, err = s.mgr.ListRuns(ctx, &filter)
+	if err != nil {
+		return nil, err
 	}
-
-	return workflowRuns, nil
-}
-
-func (s *workflowsrvc) getWorkflow(ctx context.Context, name string) (*workflow.Workflow, error) {
-	if name == "" {
-		return nil, workflow.MakeBadRequest(errors.New("empty workflow name"))
-	}
-	wf := s.store.GetWorkflow(ctx, name)
-	if wf == nil {
-		return nil, workflow.MakeNotFound(errors.New("could not find a workflow with the specified name"))
-	}
-	return wf, nil
-}
-
-func newRestWorkflowAssignment(workflowName string, codesets []*domain.AssignedCodeset, listener *domain.WorkflowListener) *workflow.WorkflowAssignment {
-	assignment := &workflow.WorkflowAssignment{
-		Workflow: &workflowName,
-		Status: &workflow.WorkflowAssignmentStatus{
-			Available: &listener.Available,
-			URL:       &listener.DashboardURL,
-		},
-	}
-	for _, c := range codesets {
-		assignment.Codesets = append(assignment.Codesets, &workflow.Codeset{
-			Name:        c.Codeset.Name,
-			Project:     c.Codeset.Project,
-			Description: c.Codeset.Description,
-			Labels:      c.Codeset.Labels,
-			URL:         &c.Codeset.URL,
-		})
-	}
-	return assignment
-}
-
-func (s *workflowsrvc) unassignCodesetFromWorkflow(ctx context.Context, workflowName string, codeset *domain.Codeset) (err error) {
-	assignment := s.store.GetAssignedCodeset(ctx, workflowName, codeset)
-	if assignment == nil {
-		err = fmt.Errorf("workflow not assigned to codeset")
-		s.logger.Print(err)
-		return workflow.MakeNotFound(err)
-	}
-
-	if assignment.WebhookID != nil {
-		err = s.codesetStore.DeleteWebhook(ctx, codeset, assignment.WebhookID)
-		if err != nil {
-			s.logger.Print(err)
-			return err
-		}
-	}
-
-	if len(s.store.GetAssignedCodesets(ctx, workflowName)) == 1 {
-		err = s.backend.DeleteWorkflowListener(ctx, workflowName)
-		if err != nil {
-			s.logger.Print(err)
-			return err
-		}
-	}
-	s.store.DeleteCodesetAssignment(ctx, workflowName, codeset)
 	return
 }

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -180,7 +180,7 @@ func (s *workflowsrvc) ListRuns(ctx context.Context, w *workflow.ListRunsPayload
 	}
 
 	for _, workflow := range workflows {
-		runs, err := s.backend.ListWorkflowRuns(ctx, *workflow, filters)
+		runs, err := s.backend.ListWorkflowRuns(ctx, workflow, &filters)
 		if err != nil {
 			s.logger.Print(err)
 			return nil, err


### PR DESCRIPTION
WorkflowManager provides functions for managing workflows. Any operation
that needs to interact with the workflow store and backend should be done
through the functions offered by the WorkflowManager as it should be the only
object that interfaces with both.

The idea is for the Workflow service to consume the functions provided by the
Workflow Manager when it needs to perform operations on the workflow store/backend,
instead of directly calling the workflow store/backend and building the logic around
them. This does not only provider better control over the store/backend, but also moves
the logic away from the service to the workflow manager.

This PR also includes some improvements workflows:
- Add `logger` to the Tekton WorkflowBackend struct and remove it from its functions.
- On WorkflowBackend change the parameters of the ListRuns function to reference structs instead of passing the struct itself.
- More generic definition for `WorkflowRunFilter`
- Add common workflow errors to the workflow domain
- Design: remove the not found error from the List function.