### PR TITLE
Make sure config file exists before attempting to write it

### DIFF
--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -60,7 +60,7 @@ func initializeConfig(cmd *cobra.Command) error {
 	viper.SetConfigName(common.ConfigFileName)
 
 	// Set the config format and extension
-	viper.SetConfigType("yaml")
+	viper.SetConfigType(common.ConfigFileType)
 
 	// Set paths where viper should look for the config file.
 	if dirname, err := os.Getwd(); err == nil {

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -63,11 +63,8 @@ func initializeConfig(cmd *cobra.Command) error {
 	viper.SetConfigType(common.ConfigFileType)
 
 	// Set paths where viper should look for the config file.
-	if dirname, err := os.Getwd(); err == nil {
-		viper.AddConfigPath(filepath.Join(dirname, common.ConfigHomeSubdir))
-	}
 	if dirname, err := os.UserHomeDir(); err == nil {
-		viper.AddConfigPath(filepath.Join(dirname, common.ConfigHomeSubdir))
+		viper.AddConfigPath(filepath.Join(dirname, common.ConfigHomeSubdir, common.ConfigFuseMLSubdir))
 	}
 
 	// Attempt to read the config file, gracefully ignoring errors

--- a/pkg/cli/codeset/set.go
+++ b/pkg/cli/codeset/set.go
@@ -3,9 +3,11 @@ package codeset
 import (
 	"fmt"
 
-	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
 )
 
 // SetOptions holds the options for 'codeset set' sub command
@@ -57,8 +59,8 @@ func (o *SetOptions) run() error {
 
 	viper.Set("CurrentCodeset", o.Name)
 
-	if err := viper.WriteConfig(); err != nil {
-		return err
+	if err := common.WriteConfigFile(); err != nil {
+		return errors.Wrap(err, "Error writing config file")
 	}
 
 	fmt.Printf("Current codeset set to %s.\n", o.Name)

--- a/pkg/cli/common/global.go
+++ b/pkg/cli/common/global.go
@@ -5,6 +5,8 @@ import "fmt"
 const (
 	// ConfigFileName is the name of the FuseML configuration file (without extension)
 	ConfigFileName = "config"
+	// ConfigFileType is the type of default config file
+	ConfigFileType = "yaml"
 	// ConfigHomeSubdir is the subdirectory where the FuseML configuration files is located
 	ConfigHomeSubdir = ".fuseml"
 	// DefaultHTTPTimeout is the default HTTP timeout value

--- a/pkg/cli/common/global.go
+++ b/pkg/cli/common/global.go
@@ -7,8 +7,10 @@ const (
 	ConfigFileName = "config"
 	// ConfigFileType is the type of default config file
 	ConfigFileType = "yaml"
-	// ConfigHomeSubdir is the subdirectory where the FuseML configuration files is located
-	ConfigHomeSubdir = ".fuseml"
+	// ConfigHomeSubdir is the main subdirectory where the user configuration files are located
+	ConfigHomeSubdir = ".config"
+	// ConfigFuseMLSubdir is the subdirectory where the FuseML configuration file is located
+	ConfigFuseMLSubdir = "fuseml"
 	// DefaultHTTPTimeout is the default HTTP timeout value
 	DefaultHTTPTimeout = 30
 )

--- a/pkg/cli/common/util.go
+++ b/pkg/cli/common/util.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
 
 // CheckErr prints a user friendly error to STDERR and exits with a non-zero
@@ -68,5 +72,36 @@ func LoadFileIntoVar(filePath string, destContent *string) error {
 
 	*destContent = string(content)
 
+	return nil
+}
+
+// WriteConfigFile writes new content of the config file.
+// If the file does not exist, it is created at default location
+// TODO temporary solution until upstream https://github.com/spf13/viper/issues/433 is fixed
+func WriteConfigFile() error {
+	cf := viper.ConfigFileUsed()
+
+	if cf == "" {
+		fullname := ConfigFileName + "." + ConfigFileType
+		if dirname, err := os.Getwd(); err == nil {
+			cf = filepath.Join(dirname, ConfigHomeSubdir, fullname)
+		}
+		if dirname, err := os.UserHomeDir(); err == nil {
+			cf = filepath.Join(dirname, ConfigHomeSubdir, fullname)
+		}
+		if cf == "" {
+			return errors.New("Failed to acquire config directory name")
+		}
+		configDirPath := filepath.Dir(cf)
+		if err := os.MkdirAll(configDirPath, os.ModePerm); err != nil {
+			return err
+		}
+
+		fmt.Printf("FuseML configuration file created at %s\n", cf)
+	}
+
+	if err := viper.WriteConfigAs(cf); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/cli/common/util.go
+++ b/pkg/cli/common/util.go
@@ -83,11 +83,8 @@ func WriteConfigFile() error {
 
 	if cf == "" {
 		fullname := ConfigFileName + "." + ConfigFileType
-		if dirname, err := os.Getwd(); err == nil {
-			cf = filepath.Join(dirname, ConfigHomeSubdir, fullname)
-		}
 		if dirname, err := os.UserHomeDir(); err == nil {
-			cf = filepath.Join(dirname, ConfigHomeSubdir, fullname)
+			cf = filepath.Join(dirname, ConfigHomeSubdir, ConfigFuseMLSubdir, fullname)
 		}
 		if cf == "" {
 			return errors.New("Failed to acquire config directory name")

--- a/pkg/cli/project/set.go
+++ b/pkg/cli/project/set.go
@@ -3,9 +3,11 @@ package project
 import (
 	"fmt"
 
-	"github.com/fuseml/fuseml-core/pkg/cli/common"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/fuseml/fuseml-core/pkg/cli/common"
 )
 
 // SetOptions holds the options for 'project set' sub command
@@ -57,8 +59,8 @@ func (o *SetOptions) run() error {
 
 	viper.Set("CurrentProject", o.Name)
 
-	if err := viper.WriteConfig(); err != nil {
-		return err
+	if err := common.WriteConfigFile(); err != nil {
+		return errors.Wrap(err, "Error writing config file")
 	}
 
 	fmt.Printf("Current project set to %s.\n", o.Name)


### PR DESCRIPTION
This is a workaround for https://github.com/spf13/viper/issues/433;
once it is fixed, viper.WriteConfig should be able to create the config
file if it does not exist.