### PR TITLE
tekton: Use different service accounts for triggers and pipelines

### DIFF
--- a/pkg/core/tekton/constants.go
+++ b/pkg/core/tekton/constants.go
@@ -2,7 +2,8 @@ package tekton
 
 const (
 	pipelineRunPrefix         = "fuseml-"
-	pipelineRunServiceAccount = "staging-triggers-admin"
+	pipelineRunServiceAccount = "fuseml-workloads"
+	triggersServiceAccount    = "tekton-triggers"
 	workspaceAccessMode       = "ReadWriteOnce"
 	workspaceSize             = "2Gi"
 	inputTypeCodeset          = "codeset"

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -498,7 +498,7 @@ func generateTriggerBinding(template *v1alpha1.TriggerTemplate) *v1alpha1.Trigge
 
 func generateEventListener(template *v1alpha1.TriggerTemplate, binding *v1alpha1.TriggerBinding) *v1alpha1.EventListener {
 	elb := builder.NewEventListenerBuilder(template.Name, template.Namespace)
-	elb.ServiceAccount(pipelineRunServiceAccount)
+	elb.ServiceAccount(triggersServiceAccount)
 	elb.TriggerBinding(template.Name, binding.Name)
 	return &elb.EventListener
 }

--- a/pkg/core/tekton/testdata/tekton-event-listener.yaml
+++ b/pkg/core/tekton/testdata/tekton-event-listener.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mlflow-sklearn-e2e
   namespace: test-namespace
 spec:
-  serviceAccountName: staging-triggers-admin
+  serviceAccountName: tekton-triggers
   triggers:
     - bindings:
         - ref: mlflow-sklearn-e2e

--- a/pkg/core/tekton/testdata/tekton-pipeline-run.yaml
+++ b/pkg/core/tekton/testdata/tekton-pipeline-run.yaml
@@ -29,7 +29,7 @@ spec:
           - name: revision
             value: main
         type: git
-  serviceAccountName: staging-triggers-admin
+  serviceAccountName: fuseml-workloads
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/pkg/core/tekton/testdata/tekton-trigger-template.yaml
+++ b/pkg/core/tekton/testdata/tekton-trigger-template.yaml
@@ -47,7 +47,7 @@ spec:
                 - name: revision
                   value: $(tt.params.codeset-version)
               type: git
-        serviceAccountName: staging-triggers-admin
+        serviceAccountName: fuseml-workloads
         workspaces:
           - name: source
             volumeClaimTemplate:


### PR DESCRIPTION
Instead of sharing the same service account, use different service
accounts for the event listener and running the workflows. This allows
configuring the service account's permissions specifically for each
case.

Depends-on: https://github.com/fuseml/fuseml/pull/172