### PR TITLE
Do not create a new run when reassigning a workflow to a codeset

### DIFF
--- a/pkg/core/manager/workflow.go
+++ b/pkg/core/manager/workflow.go
@@ -86,6 +86,11 @@ func (mgr *WorkflowManager) AssignToCodeset(ctx context.Context, name, codesetPr
 		return nil, nil, err
 	}
 
+	assignment, err := mgr.workflowStore.GetAssignedCodeset(ctx, name, codeset)
+	if err == nil {
+		return wfListener, assignment.WebhookID, nil
+	}
+
 	webhookID, err = mgr.codesetStore.CreateWebhook(ctx, codeset, wfListener.URL)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Currently, every time that a workflow is assigned to a codeset it creates
a new workflow run, even if the assignment already exists. This change makes
it to not create a new workflow run when the assignment already exists, but
only for new assignments.