### PR TITLE
extensions: fix endpoint URL encoding

### DIFF
--- a/design/extension.go
+++ b/design/extension.go
@@ -354,7 +354,6 @@ var _ = Service("extension", func() {
 				Example("s3")
 			})
 			Field(3, "url", String, "Endpoint URL", func() {
-				Format(FormatURI)
 				MaxLength(200)
 				Example("https://mlflow.10.120.130.140.nip.io")
 			})
@@ -452,8 +451,8 @@ var _ = Service("extension", func() {
 				Example("s3")
 			})
 			Field(3, "url", String, "Endpoint URL", func() {
-				Format(FormatURI)
 				MaxLength(200)
+
 				Example("https://mlflow.10.120.130.140.nip.io")
 			})
 			Required("extension_id", "service_id", "url")
@@ -815,7 +814,6 @@ var ExtensionEndpoint = Type("ExtensionEndpoint", func() {
 	Field(tag, "url", String,
 		`Endpoint URL. In case of k8s controllers and operators, the URL points to the cluster API.
 Also used to uniquely identifies an endpoint within the scope of a service`, func() {
-			Format(FormatURI)
 			MaxLength(200)
 			Example("https://mlflow.10.120.130.140.nip.io")
 		})

--- a/pkg/cli/client/extension.go
+++ b/pkg/cli/client/extension.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	goahttp "goa.design/goa/v3/http"
 
@@ -23,7 +24,7 @@ func NewExtensionClient(scheme string, host string, doer goahttp.Doer, encoder f
 	return ec
 }
 
-// RegisterExtensionFromFile - register an extension from a file YAML or JSON descriptor.
+// ReadExtensionFromFile - register an extension from a file YAML or JSON descriptor.
 func (ec *ExtensionClient) ReadExtensionFromFile(filepath string) (res *extension.Extension, err error) {
 
 	var extDescriptor string
@@ -168,7 +169,9 @@ func (ec *ExtensionClient) AddEndpoint(ep *extension.ExtensionEndpoint) (res *ex
 
 // DeleteEndpoint - delete an endpoint from an extension service.
 func (ec *ExtensionClient) DeleteEndpoint(extensionID, serviceID, URL string) error {
-	request, err := extensionc.BuildDeleteEndpointPayload(extensionID, serviceID, URL)
+
+	url := url.QueryEscape(URL)
+	request, err := extensionc.BuildDeleteEndpointPayload(extensionID, serviceID, url)
 	if err != nil {
 		return err
 	}
@@ -184,6 +187,8 @@ func (ec *ExtensionClient) DeleteEndpoint(extensionID, serviceID, URL string) er
 // UpdateEndpoint - update the attributes of an endpoint from an extension service.
 func (ec *ExtensionClient) UpdateEndpoint(endpoint *extension.ExtensionEndpoint) (res *extension.ExtensionEndpoint, err error) {
 
+	url := url.QueryEscape(*endpoint.URL)
+	endpoint.URL = &url
 	response, err := ec.c.UpdateEndpoint()(context.Background(), endpoint)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The URL endpoint attribute is used as a URL path token, which means
it needs to be URL-escaped by the CLI and URL-unescaped by the server.

Unfortunately, goa doesn't support this use-case, and worse, handling
the URL-escaping outside of goa clashes with the URL format
validation.

This commit removes the URL format validation for the endpoint URL
field and handles the URL escaping in the CLI/server code.