### PR TITLE
[0.2] Fix workflow list runs when status is a failed reason

### DIFF
--- a/design/workflow.go
+++ b/design/workflow.go
@@ -231,7 +231,6 @@ var _ = Service("workflow", func() {
 				Example("mlflow-project-001")
 			})
 			Field(4, "status", String, "status of the workflow runs to list", func() {
-				Enum("", "Started", "Running", "Cancelled", "Succeeded", "Failed", "Completed", "Timeout")
 				Example("Succeeded")
 
 			})
@@ -517,7 +516,6 @@ var WorkflowRun = Type("WorkflowRun", func() {
 		Example("2021-04-09T06:20:35Z")
 	})
 	Field(7, "status", String, "The current status of the workflow run", func() {
-		Enum("Started", "Running", "Cancelled", "Succeeded", "Failed", "Completed", "Timeout", "Unknown")
 		Example("Succeeded")
 	})
 	Field(8, "URL", String, "Dashboard URL to the workflow run")

--- a/pkg/cli/workflow/list_runs.go
+++ b/pkg/cli/workflow/list_runs.go
@@ -1,7 +1,9 @@
 package workflow
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -34,6 +36,12 @@ func formatRunDuration(object interface{}, column string, field interface{}) str
 
 func formatRunStatus(object interface{}, column string, field interface{}) string {
 	if wr, ok := object.(*workflow.WorkflowRun); ok {
+		// The status may also include the reason for a failed run (e.g. "Failed (CouldntCreateWorkspacePVC)"),
+		// color the status only.
+		status := strings.Split(wr.Status, " (")
+		if len(status) > 1 {
+			return fmt.Sprintf("%s (%s", formatted.ColorStatus(status[0]), status[1])
+		}
 		return formatted.ColorStatus(wr.Status)
 	}
 	return ""

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -654,7 +654,13 @@ func (w *WorkflowBackend) toWorkflowRun(wf *domain.Workflow, p v1beta1.PipelineR
 // Some PipelineRun status starts with "PipelineRun" see:
 // https://github.com/tektoncd/pipeline/blob/main/docs/pipelineruns.md#monitoring-execution-status
 func pipelineReasonToWorkflowStatus(reason string) string {
-	return strings.TrimPrefix(reason, "PipelineRun")
+	expectedStatus := []string{"Succeeded", "Running", "Cancelled", "Completed", "Pending", "Started", "Failed", "Unknown"}
+	status := strings.TrimPrefix(reason, "PipelineRun")
+	// If it is not an expected Status it means that the job failed and the status is the reason it failed
+	if !util.StringInSlice(status, expectedStatus) {
+		status = fmt.Sprintf("Failed (%s)", status)
+	}
+	return status
 }
 
 func getPipelineResourceParamValue(paramName string, resource v1beta1.PipelineResourceBinding) *string {


### PR DESCRIPTION
- design: Removes the `Enum` filter as the status can also returns
a workflow failure reason.
- when a workflow run fails report its status as `Failed (reason)`.

Fixes: https://github.com/fuseml/fuseml/issues/221

Backports: #105 