### PR TITLE
Build multi-arch fuseml-core docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
@@ -97,10 +102,6 @@ jobs:
           esac
           echo "IMG=ghcr.io/${GITHUB_REPOSITORY}:${TAG}" >> $GITHUB_ENV
          
-      - name: Build image
+      - name: Build and publish multi-arch image
         run: |
-          make docker-build
-
-      - name: Push image
-        run: |
-          make docker-push
+          make docker-release

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LDFLAGS" -o fuseml_core ./cmd/fuseml_core
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "$LDFLAGS" -o fuseml_core ./cmd/fuseml_core
 
 # Use docker scratch as minimal base image to package FuseML binaries
 # Refer to https://docs.docker.com/develop/develop-images/baseimages/#create-a-simple-parent-image-using-scratch

--- a/Makefile
+++ b/Makefile
@@ -136,3 +136,7 @@ docker-build: test
 # Push the docker image
 docker-push:
 	docker push ${IMG}
+
+# Build and release a multi-arch docker image
+docker-release: test
+	docker buildx build . -t ${IMG} --build-arg LDFLAGS="$(LDFLAGS)" --platform linux/amd64,linux/arm64,linux/arm/v7 --push


### PR DESCRIPTION
Use docker buildx [1] to build a multi-arch docker image for
fuseml-core.

[1] https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images

Closes fuseml/fuseml#207