### PR TITLE
[0.2] Refactor Extensions

### DIFF
--- a/pkg/core/extension_store.go
+++ b/pkg/core/extension_store.go
@@ -2,810 +2,249 @@ package core
 
 import (
 	"context"
-	"sort"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/fuseml/fuseml-core/pkg/domain"
-	"github.com/fuseml/fuseml-core/pkg/util"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-// extensionRecord is the structure used to represent an extension in the extension store
-type extensionRecord struct {
-	domain.Extension
-	// Map of services associated with the extension, indexed by ID
-	services map[string]*extensionServiceRecord
-}
-
-type extensionServiceRecord struct {
-	domain.ExtensionService
-	// parent reference
-	extension *extensionRecord
-	// Map of endpoints associated with the service, indexed by URL
-	endpoints map[string]*extensionEndpointRecord
-	// Map of credentials associated with the service, indexed by ID
-	credentials map[string]*extensionCredentialsRecord
-}
-
-type extensionEndpointRecord struct {
-	domain.ExtensionEndpoint
-	// parent reference
-	service *extensionServiceRecord
-}
-
-type extensionCredentialsRecord struct {
-	domain.ExtensionCredentials
-	// parent reference
-	service *extensionServiceRecord
-}
-
-// ExtensionStore is an in memory store for extensions
+// ExtensionStore is an in memory store for extensions.
 type ExtensionStore struct {
 	// map of extensions indexed by ID
-	items map[string]*extensionRecord
+	items map[string]*domain.Extension
 }
 
-// NewExtensionStore returns an in-memory extension store instance
+// NewExtensionStore returns an in-memory extension store instance.
 func NewExtensionStore() *ExtensionStore {
 	return &ExtensionStore{
-		items: make(map[string]*extensionRecord),
+		items: make(map[string]*domain.Extension),
 	}
 }
 
-// simple unique extension ID generator
-func (store *ExtensionStore) generateExtensionID(extension *domain.Extension) string {
-	prefix := extension.Product
-	if prefix != "" {
-		prefix = prefix + "-"
-	}
-	for {
-		ID := prefix + rand.String(8)
-		if store.items[ID] == nil {
-			return ID
-		}
-	}
-}
-
-// simple unique extension service ID generator
-func (store *ExtensionStore) generateExtensionServiceID(extension *extensionRecord, service *domain.ExtensionService) string {
-	prefix := service.Resource
-	if prefix == "" && extension.Product != "" {
-		prefix = extension.Product + "-service"
-	}
-	if prefix != "" {
-		prefix = prefix + "-"
-	}
-	for {
-		ID := prefix + rand.String(8)
-		if extension.services[ID] == nil {
-			return ID
-		}
-	}
-}
-
-// simple unique extension credentials ID generator
-func (store *ExtensionStore) generateExtensionCredentialsID(service *extensionServiceRecord, credentials *domain.ExtensionCredentials) string {
-	prefix := service.Resource
-	if prefix == "" {
-		prefix = "creds"
-	}
-	if prefix != "" {
-		prefix = prefix + "-"
-	}
-	for {
-		ID := prefix + rand.String(8)
-		if service.credentials[ID] == nil {
-			return ID
-		}
-	}
-}
-
-// store an extension record
-func (store *ExtensionStore) storeExtensionRecord(ctx context.Context, extension *domain.ExtensionRecord) (result *extensionRecord, err error) {
-	if extension.ID == "" {
-		extension.ID = store.generateExtensionID(&extension.Extension)
-	}
-
-	extension.Registered = time.Now()
-	extension.Updated = extension.Registered
-
-	// store a copy of the input extension
-	extRecord := &extensionRecord{
-		extension.Extension,
-		make(map[string]*extensionServiceRecord),
-	}
-	store.items[extension.ID] = extRecord
-
-	// next, store services
-	for _, service := range extension.Services {
-		service.ExtensionID = extension.ID
-		_, err := store.storeServiceRecord(ctx, service, extRecord)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return extRecord, nil
-}
-
-// StoreExtension - store an extension, with all participating services, endpoints and credentials
-func (store *ExtensionStore) StoreExtension(ctx context.Context, extension *domain.ExtensionRecord) (result *domain.ExtensionRecord, err error) {
+// AddExtension adds a new extension to the store.
+func (store *ExtensionStore) AddExtension(ctx context.Context, extension *domain.Extension) (*domain.Extension, error) {
 	if store.items[extension.ID] != nil {
 		return nil, domain.NewErrExtensionExists(extension.ID)
 	}
 
-	extRecord, err := store.storeExtensionRecord(ctx, extension)
-	if err != nil {
-		// rollback everything in case of error
-		_ = store.deleteExtensionRecord(ctx, extRecord)
-		return nil, err
+	extension.EnsureID(ctx, store)
+	extension.SetCreated(ctx)
+	store.items[extension.ID] = extension
+	return extension, nil
+}
+
+// GetExtension retrieves an extension by its ID.
+func (store *ExtensionStore) GetExtension(ctx context.Context, extensionID string) (*domain.Extension, error) {
+	extension := store.items[extensionID]
+	if extension == nil {
+		return nil, domain.NewErrExtensionNotFound(extensionID)
 	}
 	return extension, nil
 }
 
-// store an extension service record
-func (store *ExtensionStore) storeServiceRecord(
-	ctx context.Context, service *domain.ExtensionServiceRecord, extRecord *extensionRecord) (result *extensionServiceRecord, err error) {
-
-	if service.ID == "" {
-		service.ID = store.generateExtensionServiceID(extRecord, &service.ExtensionService)
-	}
-
-	service.Registered = time.Now()
-	service.Updated = service.Registered
-
-	// store a copy of the input extension service
-	svcRecord := &extensionServiceRecord{
-		service.ExtensionService,
-		extRecord,
-		make(map[string]*extensionEndpointRecord),
-		make(map[string]*extensionCredentialsRecord),
-	}
-	extRecord.services[service.ID] = svcRecord
-
-	// next, store endpoints
-	for _, endpoint := range service.Endpoints {
-		endpoint.ExtensionID = extRecord.ID
-		endpoint.ServiceID = service.ID
-		_, err = store.storeEndpointRecord(ctx, endpoint, svcRecord)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// next, store credentials
-	for _, credentials := range service.Credentials {
-		credentials.ExtensionID = extRecord.ID
-		credentials.ServiceID = service.ID
-		_, err = store.storeCredentialsRecord(ctx, credentials, svcRecord)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return svcRecord, nil
-}
-
-// StoreService - store an extension service, with all participating endpoints and credentials
-func (store *ExtensionStore) StoreService(
-	ctx context.Context, service *domain.ExtensionServiceRecord) (result *domain.ExtensionServiceRecord, err error) {
-
-	extRecord := store.items[service.ExtensionID]
-	if extRecord == nil {
-		return nil, domain.NewErrExtensionNotFound(service.ExtensionID)
-	}
-
-	if extRecord.services[service.ID] != nil {
-		return nil, domain.NewErrExtensionServiceExists(extRecord.ID, service.ID)
-	}
-
-	svcRecord, err := store.storeServiceRecord(ctx, service, extRecord)
-	if err != nil {
-		// rollback everything in case of error
-		_ = store.deleteServiceRecord(ctx, svcRecord)
-		return nil, err
-	}
-	return service, nil
-
-}
-
-// store an extension endpoint record
-func (store *ExtensionStore) storeEndpointRecord(
-	ctx context.Context, endpoint *domain.ExtensionEndpoint, svcRecord *extensionServiceRecord) (result *extensionEndpointRecord, err error) {
-
-	if svcRecord.endpoints[endpoint.URL] != nil {
-		return nil, domain.NewErrExtensionEndpointExists(endpoint.ExtensionID, endpoint.ServiceID, endpoint.URL)
-	}
-
-	// store a copy of the input extension endpoint
-	endpointRecord := &extensionEndpointRecord{
-		*endpoint,
-		svcRecord,
-	}
-	svcRecord.endpoints[endpoint.URL] = endpointRecord
-	return endpointRecord, nil
-}
-
-// StoreEndpoint - store an extension endpoint
-func (store *ExtensionStore) StoreEndpoint(ctx context.Context, endpoint *domain.ExtensionEndpoint) (result *domain.ExtensionEndpoint, err error) {
-	extRecord := store.items[endpoint.ExtensionID]
-	if extRecord == nil {
-		return nil, domain.NewErrExtensionNotFound(endpoint.ExtensionID)
-	}
-	svcRecord := extRecord.services[endpoint.ServiceID]
-	if svcRecord == nil {
-		return nil, domain.NewErrExtensionServiceNotFound(endpoint.ExtensionID, endpoint.ServiceID)
-	}
-
-	_, err = store.storeEndpointRecord(ctx, endpoint, svcRecord)
-	return endpoint, err
-}
-
-// store an extension credentials record
-func (store *ExtensionStore) storeCredentialsRecord(
-	ctx context.Context, credentials *domain.ExtensionCredentials, svcRecord *extensionServiceRecord) (result *extensionCredentialsRecord, err error) {
-
-	if credentials.ID == "" {
-		credentials.ID = store.generateExtensionCredentialsID(svcRecord, credentials)
-	}
-
-	if svcRecord.credentials[credentials.ID] != nil {
-		return nil, domain.NewErrExtensionCredentialsExists(credentials.ExtensionID, credentials.ServiceID, credentials.ID)
-	}
-
-	credentials.Created = time.Now()
-	credentials.Updated = credentials.Created
-
-	// store a copy of the input extension credentials
-	credsRecord := &extensionCredentialsRecord{
-		*credentials,
-		svcRecord,
-	}
-	svcRecord.credentials[credentials.ID] = credsRecord
-
-	return credsRecord, nil
-}
-
-// StoreCredentials - store a set of extension credentials
-func (store *ExtensionStore) StoreCredentials(ctx context.Context, credentials *domain.ExtensionCredentials) (result *domain.ExtensionCredentials, err error) {
-	extRecord := store.items[credentials.ExtensionID]
-	if extRecord == nil {
-		return nil, domain.NewErrExtensionNotFound(credentials.ExtensionID)
-	}
-	svcRecord := extRecord.services[credentials.ServiceID]
-	if svcRecord == nil {
-		return nil, domain.NewErrExtensionServiceNotFound(credentials.ExtensionID, credentials.ServiceID)
-	}
-
-	_, err = store.storeCredentialsRecord(ctx, credentials, svcRecord)
-	return credentials, err
-}
-
-// Retrieve an extension record by ID
-func (store *ExtensionStore) getExtensionRecord(ctx context.Context, extensionID string) (result *extensionRecord, err error) {
-	extRecord := store.items[extensionID]
-	if extRecord == nil {
-		return nil, domain.NewErrExtensionNotFound(extensionID)
-	}
-	return extRecord, nil
-}
-
-// GetAllExtensions - retrieve all registered extensions, with all participating services, endpoints and credentials
-func (store *ExtensionStore) GetAllExtensions(ctx context.Context) (result []*domain.ExtensionRecord, err error) {
-	result = make([]*domain.ExtensionRecord, 0, len(store.items))
-	for extID := range store.items {
-		extRecord, err := store.GetExtension(ctx, extID, true)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, extRecord)
-	}
-	return result, nil
-}
-
-// GetExtension - retrieve an extension by ID
-func (store *ExtensionStore) GetExtension(ctx context.Context, extensionID string, fullTree bool) (result *domain.ExtensionRecord, err error) {
-	extRecord, err := store.getExtensionRecord(ctx, extensionID)
-	if err != nil {
-		return nil, err
-	}
-
-	result = &domain.ExtensionRecord{
-		Extension: extRecord.Extension,
-		Services:  make([]*domain.ExtensionServiceRecord, 0),
-	}
-	if !fullTree {
-		return result, nil
-	}
-
-	// sort services by ID
-	svcIDs := make([]string, 0, len(extRecord.services))
-	for svcID := range extRecord.services {
-		svcIDs = append(svcIDs, svcID)
-	}
-	sort.Strings(svcIDs)
-
-	for _, svcID := range svcIDs {
-		svcRecord := extRecord.services[svcID]
-		service := domain.ExtensionServiceRecord{
-			ExtensionService: svcRecord.ExtensionService,
-			Endpoints:        make([]*domain.ExtensionEndpoint, 0),
-			Credentials:      make([]*domain.ExtensionCredentials, 0),
-		}
-		result.Services = append(result.Services, &service)
-
-		// sort endpoints by URL
-		URLs := make([]string, 0, len(svcRecord.endpoints))
-		for URL := range svcRecord.endpoints {
-			URLs = append(URLs, URL)
-		}
-		sort.Strings(URLs)
-
-		for _, URL := range URLs {
-			endpointRecord := svcRecord.endpoints[URL]
-			service.Endpoints = append(service.Endpoints, &endpointRecord.ExtensionEndpoint)
-		}
-
-		// sort credentials by ID
-		credIDs := make([]string, 0, len(svcRecord.credentials))
-		for credID := range svcRecord.credentials {
-			credIDs = append(credIDs, credID)
-		}
-		sort.Strings(credIDs)
-
-		for _, credID := range credIDs {
-			credsRecord := svcRecord.credentials[credID]
-			service.Credentials = append(service.Credentials, &credsRecord.ExtensionCredentials)
-		}
-	}
-	return result, nil
-}
-
-// GetExtensionServices - retrieve the list of services belonging to an extension
-func (store *ExtensionStore) GetExtensionServices(ctx context.Context, extensionID string) (result []*domain.ExtensionService, err error) {
-	extRecord, err := store.getExtensionRecord(ctx, extensionID)
-	if err != nil {
-		return nil, err
-	}
-	result = make([]*domain.ExtensionService, 0)
-	for _, svcRecord := range extRecord.services {
-		result = append(result, &svcRecord.ExtensionService)
-	}
-	return result, nil
-}
-
-// Retrieve an extension service record by ID
-func (store *ExtensionStore) getServiceRecord(ctx context.Context, serviceID domain.ExtensionServiceID) (result *extensionServiceRecord, err error) {
-	extRecord, err := store.getExtensionRecord(ctx, serviceID.ExtensionID)
-	if err != nil {
-		return nil, err
-	}
-	svcRecord := extRecord.services[serviceID.ID]
-	if svcRecord == nil {
-		return nil, domain.NewErrExtensionServiceNotFound(serviceID.ExtensionID, serviceID.ID)
-	}
-	return svcRecord, nil
-}
-
-// GetService - retrieve an extension service by ID
-func (store *ExtensionStore) GetService(ctx context.Context, serviceID domain.ExtensionServiceID, fullTree bool) (result *domain.ExtensionServiceRecord, err error) {
-	svcRecord, err := store.getServiceRecord(ctx, serviceID)
-	if err != nil {
-		return nil, err
-	}
-
-	result = &domain.ExtensionServiceRecord{
-		ExtensionService: svcRecord.ExtensionService,
-		Endpoints:        make([]*domain.ExtensionEndpoint, 0),
-		Credentials:      make([]*domain.ExtensionCredentials, 0),
-	}
-
-	if !fullTree {
-		return result, nil
-	}
-
-	// sort endpoints by URL
-	URLs := make([]string, 0, len(svcRecord.endpoints))
-	for URL := range svcRecord.endpoints {
-		URLs = append(URLs, URL)
-	}
-	sort.Strings(URLs)
-
-	for _, URL := range URLs {
-		endpointRecord := svcRecord.endpoints[URL]
-		result.Endpoints = append(result.Endpoints, &endpointRecord.ExtensionEndpoint)
-	}
-
-	// sort credentials by ID
-	credIDs := make([]string, 0, len(svcRecord.credentials))
-	for credID := range svcRecord.credentials {
-		credIDs = append(credIDs, credID)
-	}
-	sort.Strings(credIDs)
-
-	for _, credID := range credIDs {
-		credsRecord := svcRecord.credentials[credID]
-		result.Credentials = append(result.Credentials, &credsRecord.ExtensionCredentials)
-	}
-
-	return result, nil
-}
-
-// GetServiceEndpoints - retrieve the list of endpoints belonging to an extension service
-func (store *ExtensionStore) GetServiceEndpoints(ctx context.Context, serviceID domain.ExtensionServiceID) (result []*domain.ExtensionEndpoint, err error) {
-	svcRecord, err := store.getServiceRecord(ctx, serviceID)
-	if err != nil {
-		return nil, err
-	}
-	result = make([]*domain.ExtensionEndpoint, 0)
-	for _, endpointRecord := range svcRecord.endpoints {
-		result = append(result, &endpointRecord.ExtensionEndpoint)
-	}
-	return result, nil
-}
-
-// GetServiceCredentials - retrieve the list of credentials belonging to an extension service
-func (store *ExtensionStore) GetServiceCredentials(ctx context.Context, serviceID domain.ExtensionServiceID) (result []*domain.ExtensionCredentials, err error) {
-	svcRecord, err := store.getServiceRecord(ctx, serviceID)
-	if err != nil {
-		return nil, err
-	}
-	result = make([]*domain.ExtensionCredentials, 0)
-	for _, credentialsRecord := range svcRecord.credentials {
-		result = append(result, &credentialsRecord.ExtensionCredentials)
-	}
-	return result, nil
-}
-
-// Retrieve an extension endpoint record by ID
-func (store *ExtensionStore) getEndpointRecord(ctx context.Context, endpointID domain.ExtensionEndpointID) (result *extensionEndpointRecord, err error) {
-	svcRecord, err := store.getServiceRecord(ctx,
-		domain.ExtensionServiceID{
-			ExtensionID: endpointID.ExtensionID,
-			ID:          endpointID.ServiceID,
-		})
-	if err != nil {
-		return nil, err
-	}
-	endpointRecord := svcRecord.endpoints[endpointID.URL]
-	if endpointRecord == nil {
-		return nil, domain.NewErrExtensionEndpointNotFound(endpointID.ExtensionID, endpointID.ServiceID, endpointID.URL)
-	}
-	return endpointRecord, nil
-}
-
-// GetEndpoint - retrieve an extension endpoint by ID
-func (store *ExtensionStore) GetEndpoint(ctx context.Context, endpointID domain.ExtensionEndpointID) (result *domain.ExtensionEndpoint, err error) {
-	endpointRecord, err := store.getEndpointRecord(ctx, endpointID)
-	if err != nil {
-		return nil, err
-	}
-	return &endpointRecord.ExtensionEndpoint, nil
-}
-
-// Retrieve an extension credentials record by ID
-func (store *ExtensionStore) getCredentialsRecord(
-	ctx context.Context, credentialsID domain.ExtensionCredentialsID) (result *extensionCredentialsRecord, err error) {
-	svcRecord, err := store.getServiceRecord(ctx,
-		domain.ExtensionServiceID{
-			ExtensionID: credentialsID.ExtensionID,
-			ID:          credentialsID.ServiceID,
-		})
-	if err != nil {
-		return nil, err
-	}
-	credentialsRecord := svcRecord.credentials[credentialsID.ID]
-	if credentialsRecord == nil {
-		return nil, domain.NewErrExtensionCredentialsNotFound(credentialsID.ExtensionID, credentialsID.ServiceID, credentialsID.ID)
-	}
-	return credentialsRecord, nil
-}
-
-// GetCredentials - retrieve a set of extension credentials by ID
-func (store *ExtensionStore) GetCredentials(ctx context.Context, credentialsID domain.ExtensionCredentialsID) (result *domain.ExtensionCredentials, err error) {
-	credentialsRecord, err := store.getCredentialsRecord(ctx, credentialsID)
-	if err != nil {
-		return nil, err
-	}
-	return &credentialsRecord.ExtensionCredentials, nil
-}
-
-// UpdateExtension - update an extension
-func (store *ExtensionStore) UpdateExtension(ctx context.Context, extension *domain.Extension) (err error) {
-	extRecord, err := store.getExtensionRecord(ctx, extension.ID)
-	if err != nil {
-		return err
-	}
-	extension.Registered = extRecord.Registered
-	extension.Updated = time.Now()
-	extRecord.Extension = *extension
-	return nil
-}
-
-// UpdateService - update a service belonging to an extension
-func (store *ExtensionStore) UpdateService(ctx context.Context, service *domain.ExtensionService) (err error) {
-	svcRecord, err := store.getServiceRecord(ctx, service.ExtensionServiceID)
-	if err != nil {
-		return err
-	}
-	service.Registered = svcRecord.Registered
-	service.Updated = time.Now()
-	svcRecord.ExtensionService = *service
-	return nil
-}
-
-// UpdateEndpoint - update an endpoint belonging to a service
-func (store *ExtensionStore) UpdateEndpoint(ctx context.Context, endpoint *domain.ExtensionEndpoint) (err error) {
-	endpointRecord, err := store.getEndpointRecord(ctx, endpoint.ExtensionEndpointID)
-	if err != nil {
-		return err
-	}
-	endpointRecord.ExtensionEndpoint = *endpoint
-	return nil
-}
-
-// UpdateCredentials - update a set of credentials belonging to a service
-func (store *ExtensionStore) UpdateCredentials(ctx context.Context, credentials *domain.ExtensionCredentials) (err error) {
-	credRecord, err := store.getCredentialsRecord(ctx, credentials.ExtensionCredentialsID)
-	if err != nil {
-		return err
-	}
-	credentials.Created = credRecord.Created
-	credentials.Updated = time.Now()
-	credRecord.ExtensionCredentials = *credentials
-	return nil
-}
-
-// Delete an extension record
-func (store *ExtensionStore) deleteExtensionRecord(ctx context.Context, extRecord *extensionRecord) error {
-	for _, svcRecord := range extRecord.services {
-		err := store.deleteServiceRecord(ctx, svcRecord)
-		if err != nil {
-			return err
-		}
-	}
-	delete(store.items, extRecord.ID)
-	return nil
-}
-
-// DeleteExtension - remove an extension and all its services, endpoints and credentials
-func (store *ExtensionStore) DeleteExtension(ctx context.Context, extensionID string) error {
-	extRecord, err := store.getExtensionRecord(ctx, extensionID)
-	if err != nil {
-		return err
-	}
-	return store.deleteExtensionRecord(ctx, extRecord)
-}
-
-// Delete an extension service record
-func (store *ExtensionStore) deleteServiceRecord(ctx context.Context, svcRecord *extensionServiceRecord) error {
-	for _, endpointRecord := range svcRecord.endpoints {
-		err := store.deleteEndpointRecord(ctx, endpointRecord)
-		if err != nil {
-			return err
-		}
-	}
-	for _, credsRecord := range svcRecord.credentials {
-		err := store.deleteCredentialsRecord(ctx, credsRecord)
-		if err != nil {
-			return err
-		}
-	}
-	delete(svcRecord.extension.services, svcRecord.ID)
-	return nil
-}
-
-// DeleteService - remove an extension service and all its endpoints and credentials
-func (store *ExtensionStore) DeleteService(ctx context.Context, serviceID domain.ExtensionServiceID) error {
-	svcRecord, err := store.getServiceRecord(ctx, serviceID)
-	if err != nil {
-		return err
-	}
-	return store.deleteServiceRecord(ctx, svcRecord)
-}
-
-// Delete an extension endpoint record
-func (store *ExtensionStore) deleteEndpointRecord(ctx context.Context, endpointRecord *extensionEndpointRecord) error {
-	delete(endpointRecord.service.endpoints, endpointRecord.URL)
-	return nil
-}
-
-// DeleteEndpoint - remove an extension endpoint
-func (store *ExtensionStore) DeleteEndpoint(ctx context.Context, endpointID domain.ExtensionEndpointID) error {
-	endpointRecord, err := store.getEndpointRecord(ctx, endpointID)
-	if err != nil {
-		return err
-	}
-	return store.deleteEndpointRecord(ctx, endpointRecord)
-}
-
-// Delete an extension credentials record
-func (store *ExtensionStore) deleteCredentialsRecord(ctx context.Context, credentialsRecord *extensionCredentialsRecord) error {
-	delete(credentialsRecord.service.credentials, credentialsRecord.ID)
-	return nil
-}
-
-// DeleteCredentials - remove a set of extension credentials
-func (store *ExtensionStore) DeleteCredentials(ctx context.Context, credentialsID domain.ExtensionCredentialsID) error {
-	credentialsRecord, err := store.getCredentialsRecord(ctx, credentialsID)
-	if err != nil {
-		return err
-	}
-	return store.deleteCredentialsRecord(ctx, credentialsRecord)
-}
-
-func (store *ExtensionStore) findExtensionRecords(ctx context.Context, query *domain.ExtensionQuery) (result []*domain.ExtensionRecord, err error) {
-	result = make([]*domain.ExtensionRecord, 0)
-
-	addIfMatch := func(extRecord *extensionRecord) {
-		if query.Zone != "" && query.StrictZoneMatch && query.Zone != extRecord.Zone {
-			return
-		}
-		if query.Product != "" && query.Product != extRecord.Product {
-			return
-		}
-		if query.VersionConstraints != "" && query.VersionConstraints != extRecord.Version {
-			// try interpreting the version as a semantic version constraint
-
-			version, err := semver.NewVersion(extRecord.Version)
-			if err != nil {
-				// Version not parseable or doesn't respect semantic versioning format
-				return
-			}
-
-			constraints, err := semver.NewConstraint(query.VersionConstraints)
-			if err != nil {
-				// Constraints not parseable or not a constraints string
-				return
-			}
-
-			// Check if the version meets the constraints
-			if !constraints.Check(version) {
-				return
-			}
-		}
-
-		services, err := store.findServiceRecords(ctx, extRecord, query)
-
-		if err == nil {
-			result = append(result,
-				&domain.ExtensionRecord{
-					Extension: extRecord.Extension,
-					Services:  services,
-				})
-		}
-	}
-
-	if query.ExtensionID != "" {
-		extRecord := store.items[query.ExtensionID]
-		if extRecord != nil {
-			addIfMatch(extRecord)
-		}
-		return result, nil
-	}
-
-	for _, extRecord := range store.items {
-		addIfMatch(extRecord)
-	}
-	return result, nil
-}
-
-func (store *ExtensionStore) findServiceRecords(
-	ctx context.Context, extRecord *extensionRecord, query *domain.ExtensionQuery) (result []*domain.ExtensionServiceRecord, err error) {
-	result = make([]*domain.ExtensionServiceRecord, 0)
-
-	addIfMatch := func(svcRecord *extensionServiceRecord) {
-		if query.ServiceID != "" && query.ServiceID != svcRecord.ID {
-			return
-		}
-		if query.ServiceResource != "" && query.ServiceResource != svcRecord.Resource {
-			return
-		}
-		if query.ServiceCategory != "" && query.ServiceCategory != svcRecord.Category {
-			return
-		}
-
-		endpoints, err := store.findEndpoints(ctx, svcRecord, query)
-		if err == nil {
-			credentials, err := store.findCredentials(ctx, svcRecord, query)
+// ListExtensions retrieves all stored extensions.
+func (store *ExtensionStore) ListExtensions(ctx context.Context, query *domain.ExtensionQuery) (result []*domain.Extension) {
+	result = make([]*domain.Extension, 0, len(store.items))
+
+	if query != nil {
+		if query.ExtensionID != "" {
+			fullExtension, err := store.GetExtension(ctx, query.ExtensionID)
 			if err == nil {
-				result = append(result,
-					&domain.ExtensionServiceRecord{
-						ExtensionService: svcRecord.ExtensionService,
-						Endpoints:        endpoints,
-						Credentials:      credentials,
-					})
+				matchingExtension := fullExtension.GetExtensionIfMatch(query)
+				if matchingExtension != nil {
+					result = append(result, matchingExtension)
+				}
 			}
-		}
-	}
-
-	for _, svcRecord := range extRecord.services {
-		addIfMatch(svcRecord)
-	}
-
-	return result, nil
-}
-
-func (store *ExtensionStore) findEndpoints(
-	ctx context.Context, svcRecord *extensionServiceRecord, query *domain.ExtensionQuery) (result []*domain.ExtensionEndpoint, err error) {
-	result = make([]*domain.ExtensionEndpoint, 0)
-
-	addIfMatch := func(endpoint *domain.ExtensionEndpoint) {
-
-		if query.EndpointURL != "" && query.EndpointURL != endpoint.URL {
 			return
 		}
-		if query.Type != nil {
-			// match endpoint type, if supplied with the query
-			if *query.Type != endpoint.Type {
-				return
-			}
-		} else if query.Zone != "" {
-			// if endpoint type is not supplied with the query, determine the endpoint type
-			// by comparing the query zone (if supplied) with the extension record zone
-			//  - if the extension is in the same zone as the query, both internal and external endpoints will match
-			//  - otherwise, only external endpoints will match
-			if query.Zone != svcRecord.extension.Zone && endpoint.Type == domain.EETInternal {
-				return
+
+		for _, extension := range store.items {
+			matchingExtension := extension.GetExtensionIfMatch(query)
+			if matchingExtension != nil {
+				result = append(result, matchingExtension)
 			}
 		}
-
-		result = append(result, endpoint)
+		return
 	}
 
-	for _, endpointRecord := range svcRecord.endpoints {
-		addIfMatch(&endpointRecord.ExtensionEndpoint)
+	for _, extension := range store.items {
+		result = append(result, extension)
 	}
-
-	return result, nil
+	return
 }
 
-func (store *ExtensionStore) findCredentials(
-	ctx context.Context, svcRecord *extensionServiceRecord, query *domain.ExtensionQuery) (result []*domain.ExtensionCredentials, err error) {
-	result = make([]*domain.ExtensionCredentials, 0)
+// UpdateExtension updates an existing extension.
+func (store *ExtensionStore) UpdateExtension(ctx context.Context, newExtension *domain.Extension) error {
+	extension, err := store.GetExtension(ctx, newExtension.ID)
+	if err != nil {
+		return err
+	}
+	newExtension.Created = extension.Created
+	newExtension.Updated = time.Now()
 
-	addIfMatch := func(credentials *domain.ExtensionCredentials) {
-		if query.CredentialsID != "" && query.CredentialsID != credentials.ID {
-			return
+	for _, newExtService := range newExtension.ListServices() {
+		_, err := extension.GetService(newExtService.ID)
+		if err != nil {
+			// If the service is new, set the creation time
+			newExtService.SetCreated(newExtension.Updated)
 		}
-		// if the query is for global scoped credentials, only credentials with a global scope match
-		if query.CredentialsScope == domain.ECSGlobal && credentials.Scope != domain.ECSGlobal {
-			return
-		}
-		// if the query is for project scoped credentials, only credentials with a global scope
-		// and those project scoped to the supplied project match
-		if query.CredentialsScope == domain.ECSProject {
-			if credentials.Scope == domain.ECSUser {
-				return
-			}
-			if credentials.Scope == domain.ECSProject && !util.StringInSlice(query.Project, credentials.Projects) {
-				return
-			}
-		}
-		// if the query is for a user scoped credential, only credentials with a global scope,
-		// those project scoped to the supplied project, and those user scoped to the supplied user and project
-		// are a match
-		if query.CredentialsScope == domain.ECSUser {
-			if credentials.Scope != domain.ECSGlobal && query.Project != "" && !util.StringInSlice(query.Project, credentials.Projects) {
-				return
-			}
-			if credentials.Scope == domain.ECSUser && !util.StringInSlice(query.User, credentials.Users) {
-				return
-			}
-		}
-		result = append(result, credentials)
 	}
 
-	for _, credentialsRecord := range svcRecord.credentials {
-		addIfMatch(&credentialsRecord.ExtensionCredentials)
-	}
-
-	return result, nil
+	store.items[newExtension.ID] = newExtension
+	return nil
 }
 
-// RunExtensionQuery - run a query on the extension store to find one or more extensions, services, endpoints and credentials matching
-// the supplied criteria
-func (store *ExtensionStore) RunExtensionQuery(ctx context.Context, query *domain.ExtensionQuery) (result []*domain.ExtensionRecord, err error) {
-	return store.findExtensionRecords(ctx, query)
+// DeleteExtension deletes an extension from the store.
+func (store *ExtensionStore) DeleteExtension(ctx context.Context, extensionID string) error {
+	_, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return err
+	}
+	delete(store.items, extensionID)
+	return nil
+}
+
+// AddExtensionService adds a new extension service to an extension.
+func (store *ExtensionStore) AddExtensionService(ctx context.Context, extensionID string, service *domain.ExtensionService) (*domain.ExtensionService, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.AddService(service)
+}
+
+// GetExtensionService retrieves an extension service by its ID.
+func (store *ExtensionStore) GetExtensionService(ctx context.Context, extensionID string, serviceID string) (*domain.ExtensionService, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.GetService(serviceID)
+}
+
+// ListExtensionServices retrieves all services belonging to an extension.
+func (store *ExtensionStore) ListExtensionServices(ctx context.Context, extensionID string) ([]*domain.ExtensionService, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.ListServices(), nil
+}
+
+// UpdateExtensionService updates a service belonging to an extension.
+func (store *ExtensionStore) UpdateExtensionService(ctx context.Context, extensionID string, newService *domain.ExtensionService) error {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return err
+	}
+	return extension.UpdateService(newService)
+}
+
+// DeleteExtensionService deletes an extension service from an extension.
+func (store *ExtensionStore) DeleteExtensionService(ctx context.Context, extensionID, serviceID string) error {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return err
+	}
+	return extension.DeleteService(serviceID)
+}
+
+// AddExtensionServiceEndpoint adds a new endpoint to an extension service.
+func (store *ExtensionStore) AddExtensionServiceEndpoint(ctx context.Context, extensionID string, serviceID string, endpoint *domain.ExtensionServiceEndpoint) (*domain.ExtensionServiceEndpoint, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.AddEndpoint(serviceID, endpoint)
+}
+
+// GetExtensionServiceEndpoint retrieves an extension endpoint by its ID.
+func (store *ExtensionStore) GetExtensionServiceEndpoint(ctx context.Context, extensionID string, serviceID string, endpointID string) (*domain.ExtensionServiceEndpoint, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.GetServiceEndpoint(serviceID, endpointID)
+}
+
+// ListExtensionServiceEndpoints retrieves all endpoints belonging to an extension service.
+func (store *ExtensionStore) ListExtensionServiceEndpoints(ctx context.Context, extensionID string, serviceID string) ([]*domain.ExtensionServiceEndpoint, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.ListServiceEndpoints(serviceID)
+}
+
+// UpdateExtensionServiceEndpoint updates an endpoint belonging to an extension service.
+func (store *ExtensionStore) UpdateExtensionServiceEndpoint(ctx context.Context, extensionID string, serviceID string, endpoint *domain.ExtensionServiceEndpoint) error {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return err
+	}
+	return extension.UpdateServiceEndpoint(serviceID, endpoint)
+}
+
+// DeleteExtensionServiceEndpoint deletes an extension endpoint from an extension service.
+func (store *ExtensionStore) DeleteExtensionServiceEndpoint(ctx context.Context, extensionID, serviceID, endpointID string) error {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return err
+	}
+	return extension.DeleteServiceEndpoint(serviceID, endpointID)
+}
+
+// AddExtensionServiceCredentials adds a new credential to an extension service.
+func (store *ExtensionStore) AddExtensionServiceCredentials(ctx context.Context, extensionID string, serviceID string,
+	credentials *domain.ExtensionServiceCredentials) (*domain.ExtensionServiceCredentials, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.AddCredentials(serviceID, credentials)
+}
+
+// GetExtensionServiceCredentials retrieves an extension credential by its ID.
+func (store *ExtensionStore) GetExtensionServiceCredentials(ctx context.Context, extensionID string, serviceID string, credentialsID string) (*domain.ExtensionServiceCredentials, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.GetServiceCredentials(serviceID, credentialsID)
+}
+
+// ListExtensionServiceCredentials retrieves all credentials belonging to an extension service.
+func (store *ExtensionStore) ListExtensionServiceCredentials(ctx context.Context, extensionID string, serviceID string) ([]*domain.ExtensionServiceCredentials, error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return nil, err
+	}
+	return extension.ListServiceCredentials(serviceID)
+}
+
+// UpdateExtensionServiceCredentials updates an extension credential.
+func (store *ExtensionStore) UpdateExtensionServiceCredentials(ctx context.Context, extensionID string, serviceID string, credentials *domain.ExtensionServiceCredentials) (err error) {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return err
+	}
+	return extension.UpdateServiceCredentials(serviceID, credentials)
+}
+
+// DeleteExtensionServiceCredentials deletes an extension credential from an extension service.
+func (store *ExtensionStore) DeleteExtensionServiceCredentials(ctx context.Context, extensionID, serviceID, credentialsID string) error {
+	extension, err := store.GetExtension(ctx, extensionID)
+	if err != nil {
+		return err
+	}
+	return extension.DeleteServiceCredentials(serviceID, credentialsID)
+}
+
+// GetExtensionAccessDescriptors retrieves access descriptors belonging to an extension that matches the query.
+func (store *ExtensionStore) GetExtensionAccessDescriptors(ctx context.Context, query *domain.ExtensionQuery) (result []*domain.ExtensionAccessDescriptor, err error) {
+	result = make([]*domain.ExtensionAccessDescriptor, 0)
+
+	for _, extension := range store.ListExtensions(ctx, query) {
+		result = append(result, extension.GetAccessDescriptors()...)
+	}
+	return result, nil
 }

--- a/pkg/core/manager/extension.go
+++ b/pkg/core/manager/extension.go
@@ -18,78 +18,57 @@ func NewExtensionRegistry(extensionStore domain.ExtensionStore) *ExtensionRegist
 }
 
 // RegisterExtension - register a new extension, with all participating services, endpoints and credentials
-func (registry *ExtensionRegistry) RegisterExtension(ctx context.Context, extension *domain.ExtensionRecord) (result *domain.ExtensionRecord, err error) {
-	return registry.extensionStore.StoreExtension(ctx, extension)
+func (registry *ExtensionRegistry) RegisterExtension(ctx context.Context, extension *domain.Extension) (*domain.Extension, error) {
+	return registry.extensionStore.AddExtension(ctx, extension)
 }
 
 // AddService - add a service to an existing extension
-func (registry *ExtensionRegistry) AddService(ctx context.Context, service *domain.ExtensionServiceRecord) (result *domain.ExtensionServiceRecord, err error) {
-	if service.ExtensionID == "" {
-		return nil, domain.NewErrMissingField("service", "extension ID")
-	}
-	return registry.extensionStore.StoreService(ctx, service)
+func (registry *ExtensionRegistry) AddService(ctx context.Context, extensionID string, service *domain.ExtensionService) (*domain.ExtensionService, error) {
+	return registry.extensionStore.AddExtensionService(ctx, extensionID, service)
 }
 
 // AddEndpoint - add an endpoint to an existing extension service
-func (registry *ExtensionRegistry) AddEndpoint(
-	ctx context.Context, endpoint *domain.ExtensionEndpoint) (result *domain.ExtensionEndpoint, err error) {
-
-	if endpoint.ExtensionID == "" {
-		return nil, domain.NewErrMissingField("endpoint", "extension ID")
-	}
-	if endpoint.ServiceID == "" {
-		return nil, domain.NewErrMissingField("endpoint", "service ID")
-	}
+func (registry *ExtensionRegistry) AddEndpoint(ctx context.Context, extensionID string, serviceID string,
+	endpoint *domain.ExtensionServiceEndpoint) (*domain.ExtensionServiceEndpoint, error) {
 	if endpoint.URL == "" {
 		return nil, domain.NewErrMissingField("endpoint", "URL")
 	}
-	return registry.extensionStore.StoreEndpoint(ctx, endpoint)
+	return registry.extensionStore.AddExtensionServiceEndpoint(ctx, extensionID, serviceID, endpoint)
 }
 
 // AddCredentials - add a set of credentials to an existing extension service
-func (registry *ExtensionRegistry) AddCredentials(
-	ctx context.Context, credentials *domain.ExtensionCredentials) (result *domain.ExtensionCredentials, err error) {
-
-	if credentials.ExtensionID == "" {
-		return nil, domain.NewErrMissingField("credentials", "extension ID")
-	}
-	if credentials.ServiceID == "" {
-		return nil, domain.NewErrMissingField("credentials", "service ID")
-	}
-
-	return registry.extensionStore.StoreCredentials(ctx, credentials)
+func (registry *ExtensionRegistry) AddCredentials(ctx context.Context, extensionID string, serviceID string,
+	credentials *domain.ExtensionServiceCredentials) (*domain.ExtensionServiceCredentials, error) {
+	return registry.extensionStore.AddExtensionServiceCredentials(ctx, extensionID, serviceID, credentials)
 }
 
 // ListExtensions - list all registered extensions that match the supplied query parameters
-func (registry *ExtensionRegistry) ListExtensions(ctx context.Context, query *domain.ExtensionQuery) (result []*domain.ExtensionRecord, err error) {
-	if query == nil {
-		return registry.extensionStore.GetAllExtensions(ctx)
-	}
-	return registry.extensionStore.RunExtensionQuery(ctx, query)
+func (registry *ExtensionRegistry) ListExtensions(ctx context.Context, query *domain.ExtensionQuery) (result []*domain.Extension, err error) {
+	return registry.extensionStore.ListExtensions(ctx, query), nil
 }
 
 // GetExtension - retrieve an extension by ID and, optionally, its entire service/endpoint/credentials subtree
-func (registry *ExtensionRegistry) GetExtension(ctx context.Context, extensionID string, fullTree bool) (result *domain.ExtensionRecord, err error) {
-	return registry.extensionStore.GetExtension(ctx, extensionID, fullTree)
+func (registry *ExtensionRegistry) GetExtension(ctx context.Context, extensionID string) (*domain.Extension, error) {
+	return registry.extensionStore.GetExtension(ctx, extensionID)
 }
 
 // GetService - retrieve an extension service by ID and, optionally, its entire endpoint/credentials subtree
-func (registry *ExtensionRegistry) GetService(ctx context.Context, serviceID domain.ExtensionServiceID, fullTree bool) (result *domain.ExtensionServiceRecord, err error) {
-	return registry.extensionStore.GetService(ctx, serviceID, fullTree)
+func (registry *ExtensionRegistry) GetService(ctx context.Context, extensionID, serviceID string) (*domain.ExtensionService, error) {
+	return registry.extensionStore.GetExtensionService(ctx, extensionID, serviceID)
 }
 
 // GetEndpoint - retrieve an extension endpoint by ID
-func (registry *ExtensionRegistry) GetEndpoint(ctx context.Context, endpointID domain.ExtensionEndpointID) (result *domain.ExtensionEndpoint, err error) {
-	return registry.extensionStore.GetEndpoint(ctx, endpointID)
+func (registry *ExtensionRegistry) GetEndpoint(ctx context.Context, extensionID, serviceID, endpointURL string) (*domain.ExtensionServiceEndpoint, error) {
+	return registry.extensionStore.GetExtensionServiceEndpoint(ctx, extensionID, serviceID, endpointURL)
 }
 
 // GetCredentials - retrieve a set of extension credentials by ID
-func (registry *ExtensionRegistry) GetCredentials(ctx context.Context, credentialsID domain.ExtensionCredentialsID) (result *domain.ExtensionCredentials, err error) {
-	return registry.extensionStore.GetCredentials(ctx, credentialsID)
+func (registry *ExtensionRegistry) GetCredentials(ctx context.Context, extensionID, serviceID, credentialsID string) (*domain.ExtensionServiceCredentials, error) {
+	return registry.extensionStore.GetExtensionServiceCredentials(ctx, extensionID, serviceID, credentialsID)
 }
 
 // UpdateExtension - update an extension
-func (registry *ExtensionRegistry) UpdateExtension(ctx context.Context, extension *domain.Extension) (err error) {
+func (registry *ExtensionRegistry) UpdateExtension(ctx context.Context, extension *domain.Extension) error {
 	if extension.ID == "" {
 		return domain.NewErrMissingField("extension", "extension ID")
 	}
@@ -97,42 +76,27 @@ func (registry *ExtensionRegistry) UpdateExtension(ctx context.Context, extensio
 }
 
 // UpdateService - update a service belonging to an extension
-func (registry *ExtensionRegistry) UpdateService(ctx context.Context, service *domain.ExtensionService) (err error) {
-	if service.ExtensionID == "" {
-		return domain.NewErrMissingField("service", "extension ID")
-	}
+func (registry *ExtensionRegistry) UpdateService(ctx context.Context, extensionID string, service *domain.ExtensionService) error {
 	if service.ID == "" {
 		return domain.NewErrMissingField("service", "service ID")
 	}
-	return registry.extensionStore.UpdateService(ctx, service)
+	return registry.extensionStore.UpdateExtensionService(ctx, extensionID, service)
 }
 
 // UpdateEndpoint - update an endpoint belonging to a service
-func (registry *ExtensionRegistry) UpdateEndpoint(ctx context.Context, endpoint *domain.ExtensionEndpoint) (err error) {
-	if endpoint.ExtensionID == "" {
-		return domain.NewErrMissingField("endpoint", "extension ID")
-	}
-	if endpoint.ServiceID == "" {
-		return domain.NewErrMissingField("endpoint", "service ID")
-	}
+func (registry *ExtensionRegistry) UpdateEndpoint(ctx context.Context, extensionID string, serviceID string, endpoint *domain.ExtensionServiceEndpoint) error {
 	if endpoint.URL == "" {
 		return domain.NewErrMissingField("endpoint", "URL")
 	}
-	return registry.extensionStore.UpdateEndpoint(ctx, endpoint)
+	return registry.extensionStore.UpdateExtensionServiceEndpoint(ctx, extensionID, serviceID, endpoint)
 }
 
 // UpdateCredentials - update a set of credentials belonging to a service
-func (registry *ExtensionRegistry) UpdateCredentials(ctx context.Context, credentials *domain.ExtensionCredentials) (err error) {
-	if credentials.ExtensionID == "" {
-		return domain.NewErrMissingField("credentials", "extension ID")
-	}
-	if credentials.ServiceID == "" {
-		return domain.NewErrMissingField("credentials", "service ID")
-	}
+func (registry *ExtensionRegistry) UpdateCredentials(ctx context.Context, extensionID string, serviceID string, credentials *domain.ExtensionServiceCredentials) error {
 	if credentials.ID == "" {
 		return domain.NewErrMissingField("credentials", "credentials ID")
 	}
-	return registry.extensionStore.UpdateCredentials(ctx, credentials)
+	return registry.extensionStore.UpdateExtensionServiceCredentials(ctx, extensionID, serviceID, credentials)
 }
 
 // RemoveExtension - remove an extension from the registry
@@ -141,18 +105,18 @@ func (registry *ExtensionRegistry) RemoveExtension(ctx context.Context, extensio
 }
 
 // RemoveService - remove an extension service from the registry
-func (registry *ExtensionRegistry) RemoveService(ctx context.Context, serviceID domain.ExtensionServiceID) error {
-	return registry.extensionStore.DeleteService(ctx, serviceID)
+func (registry *ExtensionRegistry) RemoveService(ctx context.Context, extensionID, serviceID string) error {
+	return registry.extensionStore.DeleteExtensionService(ctx, extensionID, serviceID)
 }
 
 // RemoveEndpoint - remove an extension endpoint from the registry
-func (registry *ExtensionRegistry) RemoveEndpoint(ctx context.Context, endpointID domain.ExtensionEndpointID) error {
-	return registry.extensionStore.DeleteEndpoint(ctx, endpointID)
+func (registry *ExtensionRegistry) RemoveEndpoint(ctx context.Context, extensionID, serviceID, endpointID string) error {
+	return registry.extensionStore.DeleteExtensionServiceEndpoint(ctx, extensionID, serviceID, endpointID)
 }
 
 // RemoveCredentials - remove a set of extension credentials from the registry
-func (registry *ExtensionRegistry) RemoveCredentials(ctx context.Context, credentialsID domain.ExtensionCredentialsID) error {
-	return registry.extensionStore.DeleteCredentials(ctx, credentialsID)
+func (registry *ExtensionRegistry) RemoveCredentials(ctx context.Context, extensionID, serviceID, credentialsID string) error {
+	return registry.extensionStore.DeleteExtensionServiceCredentials(ctx, extensionID, serviceID, credentialsID)
 }
 
 type queryResults []*domain.ExtensionAccessDescriptor
@@ -181,42 +145,12 @@ func (s byID) Less(i, j int) bool {
 	return s.queryResults[i].Credentials.ID < s.queryResults[j].Credentials.ID
 }
 
-// RunExtensionAccessQuery - run a query on the extension registry to find one or more ways to access extensions matching given search parameters
-func (registry *ExtensionRegistry) RunExtensionAccessQuery(ctx context.Context, query *domain.ExtensionQuery) (result []*domain.ExtensionAccessDescriptor, err error) {
-
-	result = make([]*domain.ExtensionAccessDescriptor, 0)
-
-	extensions, err := registry.extensionStore.RunExtensionQuery(ctx, query)
+// GetExtensionAccessDescriptors - returns access descriptors for extensions that matches the query
+func (registry *ExtensionRegistry) GetExtensionAccessDescriptors(ctx context.Context, query *domain.ExtensionQuery) (result []*domain.ExtensionAccessDescriptor, err error) {
+	result, err = registry.extensionStore.GetExtensionAccessDescriptors(ctx, query)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, extension := range extensions {
-		for _, service := range extension.Services {
-			for _, endpoint := range service.Endpoints {
-				if len(service.Credentials) > 0 || service.AuthRequired {
-					for _, credentials := range service.Credentials {
-						accessDesc := domain.ExtensionAccessDescriptor{
-							Extension:   extension.Extension,
-							Service:     service.ExtensionService,
-							Endpoint:    *endpoint,
-							Credentials: credentials,
-						}
-						result = append(result, &accessDesc)
-					}
-				} else {
-					accessDesc := domain.ExtensionAccessDescriptor{
-						Extension:   extension.Extension,
-						Service:     service.ExtensionService,
-						Endpoint:    *endpoint,
-						Credentials: nil,
-					}
-					result = append(result, &accessDesc)
-				}
-			}
-		}
-	}
-
 	sort.Sort(byID{result})
 	return result, nil
 }

--- a/pkg/core/manager/workflow.go
+++ b/pkg/core/manager/workflow.go
@@ -193,7 +193,7 @@ func (mgr *WorkflowManager) OnDeletingCodeset(ctx context.Context, codeset *doma
 func (mgr *WorkflowManager) resolveExtensionReferences(ctx context.Context, wf *domain.Workflow) error {
 	for _, step := range wf.Steps {
 		for _, extReq := range step.Extensions {
-			accessDescList, err := mgr.extensionRegistry.RunExtensionAccessQuery(ctx, &domain.ExtensionQuery{
+			accessDescList, err := mgr.extensionRegistry.GetExtensionAccessDescriptors(ctx, &domain.ExtensionQuery{
 				ExtensionID:        extReq.ExtensionID,
 				Product:            extReq.Product,
 				VersionConstraints: extReq.VersionConstraints,


### PR DESCRIPTION
- Add `Services` field to `Extension` to store services pertaining to
the extension.
- Add `Credentials` and `Endpoints` field to `ExtensionService` to store
credentials and endpoints pertaining to the service.
- Removed *Record types as the relation between extensions, services,
credentials and endpoints are represented by the repective types.
- Removed *ID types as there is no use for the "parent" IDs.
- Moved most of the `Extension` behaviour logic out of the extension
store to the `Extension` domain.
- Renamed types:
  - `ExtensionEndpoint` to `ExtensionServiceEndpoint`
  - `ExtensionCredentials` to `ExtensionServiceCredentials`

Backports: #100 