### PR TITLE
Workflow: Add `resources` field to step

### DIFF
--- a/design/workflow.go
+++ b/design/workflow.go
@@ -327,6 +327,7 @@ var WorkflowStep = Type("WorkflowStep", func() {
 	Field(4, "outputs", ArrayOf(WorkflowStepOutput), "List of output from the step")
 	Field(5, "extensions", ArrayOf(WorkflowStepExtension), "List of extension requirements")
 	Field(6, "env", ArrayOf(WorkflowStepEnv), "List of environment variables available for the container running the step")
+	Field(7, "resources", WorkflowStepResources, "Set the resources requests and limits for the step.")
 
 	Required("name", "image")
 })
@@ -499,6 +500,15 @@ var WorkflowStepEnv = Type("WorkflowStepEnv", func() {
 	})
 
 	Required("name", "value")
+})
+
+var WorkflowStepResources = Type("WorkflowStepResources", func() {
+	Field(1, "requests", MapOf(String, String), "Resource requests", func() {
+		Example(map[string]string{"cpu": "1", "memory": "1Gi"})
+	})
+	Field(2, "limits", MapOf(String, String), "Resource limits", func() {
+		Example(map[string]string{"cpu": "2", "memory": "2Gi", "nvidia.com/gpu": "1"})
+	})
 })
 
 // WorkflowRun describes a workflow run returned when listed

--- a/pkg/core/tekton/builder/task_spec.go
+++ b/pkg/core/tekton/builder/task_spec.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // TaskSpecBuilder holds the tekton task spec definition.
@@ -76,4 +77,24 @@ func (b *TaskSpecBuilder) Result(name string) {
 	b.TaskSpec.Results = append(b.TaskSpec.Results, v1beta1.TaskResult{
 		Name: name,
 	})
+}
+
+// Resources add a Resources to the TaskSpec.
+func (b *TaskSpecBuilder) Resources(requests, limits map[string]string) {
+	b.TaskSpec.Steps[0].Resources = corev1.ResourceRequirements{}
+	if len(requests) > 0 {
+		b.TaskSpec.Steps[0].Resources.Requests = toResourceList(requests)
+	}
+
+	if len(limits) > 0 {
+		b.TaskSpec.Steps[0].Resources.Limits = toResourceList(limits)
+	}
+}
+
+func toResourceList(resources map[string]string) corev1.ResourceList {
+	res := corev1.ResourceList{}
+	for k, v := range resources {
+		res[corev1.ResourceName(k)] = resource.MustParse(v)
+	}
+	return res
 }

--- a/pkg/core/tekton/tekton.go
+++ b/pkg/core/tekton/tekton.go
@@ -584,6 +584,9 @@ func toTektonTaskSpec(step *domain.WorkflowStep, resolver *variablesResolver, en
 		tb.Env(envVar.name, envVar.value)
 	}
 
+	// set task resources requests and limits
+	tb.Resources(step.Resources.Requests, step.Resources.Limits)
+
 	return tb.TaskSpec
 }
 

--- a/pkg/core/tekton/testdata/tekton-pipeline.yaml
+++ b/pkg/core/tekton/testdata/tekton-pipeline.yaml
@@ -106,7 +106,10 @@ spec:
                 value: uW1qiFS8DTFuACXCDrM7i5zLJXbbfXd6pReyntjn
             image: $(params.IMAGE)
             name: trainer
-            resources: {}
+            resources:
+              limits:
+                cpu: 1
+                memory: 1Gi
             workingDir: /project
         workspaces:
           - mountPath: /project
@@ -152,7 +155,14 @@ spec:
                 value: uW1qiFS8DTFuACXCDrM7i5zLJXbbfXd6pReyntjn
             image: 'ghcr.io/fuseml/kfserving-predictor:0.1'
             name: predictor
-            resources: {}
+            resources:
+              limits:
+                cpu: 2
+                memory: 2Gi
+                nvidia.com/gpu: 1
+              requests:
+                cpu: 1
+                memory: 1Gi
             workingDir: /project
         workspaces:
           - mountPath: /project

--- a/pkg/core/tekton/testdata/workflow.yaml
+++ b/pkg/core/tekton/testdata/workflow.yaml
@@ -34,6 +34,10 @@ steps:
           path: '/project'
     outputs:
       - name: mlflow-model-url
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
     extensions:
       - name: mlflow-tracking
         product: mlflow
@@ -95,6 +99,14 @@ steps:
           path: '/project'
     outputs:
       - name: prediction-url
+    resources:
+      limits:
+        cpu: 2
+        memory: 2Gi
+        nvidia.com/gpu: 1
+      requests:
+        cpu: 1
+        memory: 1Gi
     extensions:
       - name: s3-storage
         service_resource: s3

--- a/pkg/domain/workflow.go
+++ b/pkg/domain/workflow.go
@@ -84,6 +84,8 @@ type WorkflowStep struct {
 	Extensions []*WorkflowStepExtension
 	// Env is the list of environment variables for the step.
 	Env []*WorkflowStepEnv
+	// Resources specify the resources requests and limits for the step.
+	Resources WorkflowStepResources
 }
 
 // WorkflowStepInput represents a input for a FuseML workflow step.
@@ -149,6 +151,14 @@ type WorkflowStepEnv struct {
 	Name string
 	// Value is the value of the environment variable.
 	Value string
+}
+
+// WorkflowStepResources represents the resources requests and limits for a FuseML workflow step.
+type WorkflowStepResources struct {
+	// Requests is a map of resource and its request value.
+	Requests map[string]string
+	// Limits is a map of resource and its limit value.
+	Limits map[string]string
 }
 
 // WorkflowRun represents a FuseML workflow run.

--- a/pkg/svc/workflow.go
+++ b/pkg/svc/workflow.go
@@ -183,6 +183,7 @@ func workflowStepsRestToDomain(restSteps []*workflow.WorkflowStep) []*domain.Wor
 			Outputs:    workflowStepOutputsRestToDomain(restStep.Outputs),
 			Extensions: workflowStepExtensionsRestToDomain(restStep.Extensions),
 			Env:        workflowStepEnvsRestToDomain(restStep.Env),
+			Resources:  workflowStepResourcesRestToDomain(restStep.Resources),
 		}
 	}
 	return steps
@@ -252,6 +253,16 @@ func workflowStepEnvsRestToDomain(restEnvs []*workflow.WorkflowStepEnv) []*domai
 	return envs
 }
 
+func workflowStepResourcesRestToDomain(restResources *workflow.WorkflowStepResources) domain.WorkflowStepResources {
+	if restResources == nil {
+		return domain.WorkflowStepResources{}
+	}
+	return domain.WorkflowStepResources{
+		Requests: restResources.Requests,
+		Limits:   restResources.Limits,
+	}
+}
+
 func workflowDomainToRest(wf *domain.Workflow) *workflow.Workflow {
 	created := wf.Created.Format(time.RFC3339)
 	return &workflow.Workflow{
@@ -308,6 +319,7 @@ func workflowStepsDomainToRest(domainSteps []*domain.WorkflowStep) []*workflow.W
 			Outputs:    workflowStepOutputsDomainToRest(domainStep.Outputs),
 			Extensions: workflowStepExtensionsDomainToRest(domainStep.Extensions),
 			Env:        workflowStepEnvsDomainToRest(domainStep.Env),
+			Resources:  workflowStepResourcesDomainToRest(domainStep.Resources),
 		}
 	}
 	return restSteps
@@ -386,6 +398,13 @@ func workflowStepEnvsDomainToRest(domainStepEnvs []*domain.WorkflowStepEnv) []*w
 		restStepEnvs[i] = &restStepEnv
 	}
 	return restStepEnvs
+}
+
+func workflowStepResourcesDomainToRest(domainStepResources domain.WorkflowStepResources) *workflow.WorkflowStepResources {
+	return &workflow.WorkflowStepResources{
+		Requests: domainStepResources.Requests,
+		Limits:   domainStepResources.Limits,
+	}
 }
 
 func workflowAssignmentDomainToRest(domainAssignment []*domain.CodesetAssignment, wfName string, wfAsgStatus *domain.WorkflowAssignmentStatus) *workflow.WorkflowAssignment {


### PR DESCRIPTION
The `resources` field can be used to specify kubernetes resources
requests and limits for container that runs the step.

Fix: https://github.com/fuseml/fuseml/issues/261